### PR TITLE
Small revisions in the implementation of dycoms rad

### DIFF
--- a/components/eam/src/physics/cam/dycoms_rad.F90
+++ b/components/eam/src/physics/cam/dycoms_rad.F90
@@ -2,39 +2,56 @@ module dycoms_rad
 
    implicit none
    private
+   public :: dycoms_radiation_init
    public :: dycoms_radiation_tend
 
    contains
 
-subroutine dycoms_radiation_tend(state, ptend, pbuf, ztodt)
+subroutine dycoms_radiation_init()
+
+   !-----------------------------------------------------------------------
+   !
+   ! Purpose:
+   ! Initialization specific to the idealized LWP-based radiation calculation
+   ! for the DYCOMS-II RF01 case (Stevens et al., 2005).
+   !
+   !-----------------------------------------------------------------------
+   use cam_history,      only: addfld
+
+   ! Add output variables
+
+   call addfld ('DYCOMS_LWPABV',(/ 'ilev' /), 'A', 'kg/m2', 'DYCOMS liquid water path integrated from TOA to the current layer interface')
+   call addfld ('DYCOMS_LWFLX', (/ 'ilev' /), 'A', 'W/m2',  'DYCOMS longwave flux profile')
+   call addfld ('DYCOMS_QRL',   (/ 'lev' /),  'A', 'K/s',   'DYCOMS longwave heating rate')
+
+end subroutine dycoms_radiation_init
+
+
+subroutine dycoms_radiation_tend(state, ptend, net_flx)
 
    use shr_kind_mod,        only: r8 => shr_kind_r8
    use ppgrid,              only: pver, pcols, pverp
-   use physics_buffer,      only: physics_buffer_desc
    use physics_types,       only: physics_state, &
                                   physics_ptend, &
                                   physics_ptend_init
    use physconst,           only: gravit, cpair
-   use physics_buffer,      only: pbuf_get_index, pbuf_get_field
+   use constituents,        only: cnst_get_ind
    use cam_history,         only: outfld
 
    implicit none
    
    type(physics_state), intent(in), target :: state
    type(physics_ptend), intent(out) :: ptend
-   type(physics_buffer_desc), pointer :: pbuf(:)
-   real(r8), intent(in) :: ztodt
-   
-   !-----------------------------------------------------------------------------------
 
+   real(r8), intent(out) :: net_flx(pcols)
+   
    integer :: ncol
    integer :: lchnk
+   integer :: ixcldliq
 
-   real(r8) :: pint(1:pcols,1:pver+1)
-
-   ! array shape correct?
-   real(r8) :: lwp(1:pcols,1:pver+1)
-   real(r8) :: radflux(1:pcols,1:pver+1)
+   real(r8) :: lwp_in_layer(pcols)
+   real(r8) :: lwp_abv(1:pcols,1:pverp)
+   real(r8) :: radflux(1:pcols,1:pverp)
    real(r8) :: qrl(1:pcols,1:pver)
 
    ! Diagnostic outputs - vertical profiles
@@ -44,57 +61,67 @@ subroutine dycoms_radiation_tend(state, ptend, pbuf, ztodt)
                           F1 = 22.0_r8, &
                           kappa = 85.0_r8
 
-   real(r8), pointer, dimension(:,:) :: iclwp, cld
-
    integer :: i, k
 
+   !-----------------------------------------------------------------------------------
    ncol = state%ncol
    lchnk = state%lchnk
-   pint(1:ncol,1:pver+1) = state%pint(1:ncol,1:pver+1)
 
-   call pbuf_get_field(pbuf, pbuf_get_index('ICLWP'), iclwp)
-   call pbuf_get_field(pbuf, pbuf_get_index('CLD'), cld)
+   ! Calculate liquid water path integrated from model top to a layer interface of interest.
+   ! Note that in this highly idealized case, we are not making any assumptions about cloud overlap,
+   ! hence grid-box mean cloud liquid mixing ratio is used here.
 
-   lwp = 0.0_r8
-   do k=2,pver+1
+   call cnst_get_ind('CLDLIQ',ixcldliq)
+
+   lwp_abv(:,:) = 0.0_r8
+   do k=2,pverp
+      lwp_in_layer(:ncol) = state%q(:ncol,k-1,ixcldliq) * state%pdel(:ncol,k-1) /gravit
+      lwp_abv(:ncol,k) = lwp_abv(:ncol,k-1) + lwp_in_layer(:ncol) 
+   end do
+
+   ! Calculate upwelling LW flux at layer interfaces
+   ! using the first 2 RHS terms in Eq. (3) of Stevens et al. (2005), "Evaluation of
+   ! Large-Eddy Simulations via Observations of Nocturnal Marine Stratocumulus"
+
+   do k = 1, pverp
       do i = 1,ncol
-         lwp(i,k) = lwp(i,k-1) + iclwp(i,k-1)*cld(i,k-1)
+         radflux(i, k) = F0*exp(-kappa*lwp_abv(i,k)) &
+                       + F1*exp(-kappa*(lwp_abv(i,pverp)-lwp_abv(i,k)))
       end do
    end do
 
-   do k = 1, pver+1
-      do i = 1,ncol
-         radflux(i, k) = F0*exp(-kappa*lwp(i,k)) + F1*exp(-kappa*(lwp(i,pver+1)-lwp(i,k)))
-      end do
-   end do
+   ! Calculate cp*dT/dt
 
    do k = 1,pver
-      do i = 1,ncol
-         qrl(i,k) = (radflux(i,k+1)-radflux(i,k))*gravit/(pint(i,k+1)-pint(i,k))
-      end do
+      qrl(:ncol,k) = (radflux(:ncol,k+1)-radflux(:ncol,k)) * gravit / state%pdel(:ncol,k)
    end do
 
+   !--------------------------------------------------------------------------
+   ! Assign values to arrays needed by the host model
+   !--------------------------------------------------------------------------
    call physics_ptend_init(ptend, state%psetcols, 'dycoms_radheat', ls=.true.) 
    ptend%s(:ncol,:) = qrl(:ncol,:)
 
+   ! Net flux into the atm column = net incoming LW at sfc - net outgoing LW at TOP.
+   ! SW fluxes are zero.
+
+   net_flx(1:ncol) = radflux(:ncol,pverp) - radflux(:ncol,1)
+
+   !--------------------------------------------------------------------------
    ! Prepare diagnostic outputs following existing radiation scheme patterns
-   
+   !--------------------------------------------------------------------------
    ! Heating rate for diagnostics (convert to K/s)
-   do k = 1,pver
-      do i = 1,ncol
-         qrl_diag(i,k) = qrl(i,k) / cpair
-      end do
-   end do
+   qrl_diag(:ncol,:pver) = qrl(:ncol,:pver) / cpair
 
    ! Output diagnostic fields to history buffer following existing patterns
    ! LWP vertical profile (kg/m²) - cumulative from TOA to each level
-   call outfld('DYCOMS_LWP',   lwp(1:ncol,1:pver+1),     ncol, lchnk)
+   call outfld('DYCOMS_LWPABV', lwp_abv(1:ncol,1:pverp), ncol, lchnk)
    
    ! Longwave flux vertical profile (W/m²) at interfaces
-   call outfld('DYCOMS_LWFLX', radflux(1:ncol,1:pver+1), ncol, lchnk)  
+   call outfld('DYCOMS_LWFLX', radflux(1:ncol,1:pverp), ncol, lchnk)  
    
    ! Longwave heating rate vertical profile (K/s)
-   call outfld('DYCOMS_QRL',   qrl_diag(1:ncol,1:pver),  ncol, lchnk)
+   call outfld('DYCOMS_QRL',  qrl_diag(1:ncol,1:pver), ncol, lchnk)
 
    return
 

--- a/components/eam/src/physics/cam/dycoms_rad.F90
+++ b/components/eam/src/physics/cam/dycoms_rad.F90
@@ -49,13 +49,15 @@ subroutine dycoms_radiation_tend(state, ptend, net_flx)
    integer :: lchnk
    integer :: ixcldliq
 
-   real(r8) :: lwp_in_layer(pcols)
-   real(r8) :: lwp_abv(1:pcols,1:pverp)
-   real(r8) :: radflux(1:pcols,1:pverp)
-   real(r8) :: qrl(1:pcols,1:pver)
+   real(r8) :: lwp_in_layer(pcols)       ! Liquid water path (kg/m2) within a model layer
+   real(r8) ::      lwp_abv(pcols,pverp) ! Cumulative liquid water path above each model interface,
+                                         ! i.e., integral from model top to the current interface.
+                                         ! Equivalent to Q(z,inf)/kappa in Stevens et al 2005
+   real(r8) :: radflux(pcols,pverp)      ! Net longwave radiative flux (W/m2) at layer interface (positive upward)
+   real(r8) ::     qrl(pcols,pver)       ! cp*dT/dt due to longwave radiation (J/kg/s = W/kg)
 
    ! Diagnostic outputs - vertical profiles
-   real(r8) :: qrl_diag(1:pcols,1:pver) ! LW heating rate for diagnostics (K/s)
+   real(r8) :: qrl_diag(1:pcols,1:pver)  ! LW heating rate for diagnostics, i.e., dT/dt (K/s)
 
    real(r8), parameter :: F0 = 70.0_r8, &
                           F1 = 22.0_r8, &

--- a/components/eam/src/physics/cam/dycoms_rad.F90
+++ b/components/eam/src/physics/cam/dycoms_rad.F90
@@ -79,7 +79,7 @@ subroutine dycoms_radiation_tend(state, ptend, net_flx)
       lwp_abv(:ncol,k) = lwp_abv(:ncol,k-1) + lwp_in_layer(:ncol) 
    end do
 
-   ! Calculate upwelling LW flux at layer interfaces
+   ! Calculate net LW flux (positive upward) at layer interfaces
    ! using the first 2 RHS terms in Eq. (3) of Stevens et al. (2005), "Evaluation of
    ! Large-Eddy Simulations via Observations of Nocturnal Marine Stratocumulus"
 
@@ -102,7 +102,8 @@ subroutine dycoms_radiation_tend(state, ptend, net_flx)
    call physics_ptend_init(ptend, state%psetcols, 'dycoms_radheat', ls=.true.) 
    ptend%s(:ncol,:) = qrl(:ncol,:)
 
-   ! Net flux into the atm column = net incoming LW at sfc - net outgoing LW at TOP.
+   ! Net flux into the atm column =   net LW flux coming into the column at sfc
+   !                                - net LW flux going out of the column at model top
    ! SW fluxes are zero.
 
    net_flx(1:ncol) = radflux(:ncol,pverp) - radflux(:ncol,1)

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -292,11 +292,6 @@ subroutine phys_register
        ! register chemical constituents including aerosols ...
        call chem_register(species_class)
 
-       ! Register DYCOMS radiation diagnostic variables
-       call addfld ('DYCOMS_LWP',   (/ 'ilev' /), 'A', 'kg/m2', 'DYCOMS liquid water path profile')
-       call addfld ('DYCOMS_LWFLX', (/ 'ilev' /), 'A', 'W/m2',  'DYCOMS longwave flux profile')  
-       call addfld ('DYCOMS_QRL',   (/ 'lev' /),  'A', 'K/s',   'DYCOMS longwave heating rate')
-
       ! Register CLUBB mixing length scale diagnostic variables
       call addfld ('LSCALE',    (/ 'ilev' /), 'A', 'm', 'Mixing Length Scale')
       call addfld ('LSCALE_UP', (/ 'ilev' /), 'A', 'm', 'Upward Mixing Length Scale')
@@ -763,6 +758,7 @@ subroutine phys_init( phys_state, phys_tend, pbuf2d, cam_out )
     use cam3_ozone_data,    only: cam3_ozone_data_on, cam3_ozone_data_init
     use radheat,            only: radheat_init
     use radiation,          only: radiation_init
+    use dycoms_rad,         only: dycoms_radiation_init
     use cloud_diagnostics,  only: cloud_diagnostics_init
     use co2_diagnostics,    only: co2_diags_init
     use stratiform,         only: stratiform_init
@@ -939,6 +935,7 @@ subroutine phys_init( phys_state, phys_tend, pbuf2d, cam_out )
 
     call t_startf ('radiation_init')
     call radiation_init(phys_state,pbuf2d)
+    call dycoms_radiation_init()
     call t_stopf ('radiation_init')
 
     call rad_solar_var_init()
@@ -3092,8 +3089,11 @@ case (0)
 
 case (1) ! Simplified radiation for DYCOMS SCM case following Stevens et al. (2005)
 
-    call dycoms_radiation_tend(state, ptend, pbuf, ztodt)
+    call dycoms_radiation_tend(state, ptend, net_flx)
+    tend%flx_net(:ncol) = net_flx(:ncol)
+
     call physics_update(state, ptend, ztodt, tend)
+    call check_energy_chng(state, tend, "dycoms_radheat", nstep, ztodt, zero, zero, zero, net_flx)
 
 case default
 


### PR DESCRIPTION
- Calculate LWP using CLDLIQ (a state component) instead of ICLWP and CLD (which are in pbuf) to avoid potential dependency on choice of cloud microphysics scheme and ambiguity in the defintion of cloud fraction (liquid or ice; stratiform or deep Cu or total).

- Change output variable name "DYCOMS_LWP" to "DYCOMS_LWPABV" to emphasize the integral is from TOM to the current layer interface;

- Minor style/cosmetic changes;

I did a test run using SHOC and `i_rad_scheme = 1` (i.e., DYCOMS rad) and had a quick look at the `DYCOMS_xxx` output variables using `ncdump`. The numbers look reasonable. (For the run script I used, see [this commit](https://github.com/huiwanpnnl/mr_scm/commit/95a69d51fc2239582f882f683f642b9f92cbea7a) in the script repo.)