### PR TITLE
Some refactor and minor changes for Lscale diagnostics

### DIFF
--- a/components/eam/src/physics/cam/clubb_intr.F90
+++ b/components/eam/src/physics/cam/clubb_intr.F90
@@ -877,13 +877,15 @@ end subroutine clubb_init_cnst
     endif
 
     !  These are default CLUBB output.  Not the higher order history budgets
+
+    call addfld ('LSCALE_CLUBB',     (/ 'lev' /), 'A',     'm',     'CLUBB Mixing Length Scale')
+    call addfld ('LSCALE_UP_CLUBB',  (/ 'lev' /), 'A',     'm',     'CLUBB Upward Mixing Length Scale')
+    call addfld ('LSCALE_DOWN_CLUBB',(/ 'lev' /), 'A',     'm',     'CLUBB Downward Mixing Length Scale')
+
     call addfld ('RHO_CLUBB',    (/ 'ilev' /), 'A',        'kg/m3', 'Air Density')
     call addfld ('UP2_CLUBB',    (/ 'ilev' /), 'A',        'm2/s2', 'Zonal Velocity Variance')
     call addfld ('VP2_CLUBB',    (/ 'ilev' /), 'A',        'm2/s2', 'Meridional Velocity Variance')
     call addfld ('WP2_CLUBB',    (/ 'ilev' /), 'A',        'm2/s2', 'Vertical Velocity Variance')
-    call addfld ('LSCALE_CLUBB', (/ 'ilev' /), 'A',            'm', 'CLUBB Mixing Length Scale')
-    call addfld ('LSCALE_UP_CLUBB', (/ 'ilev' /), 'A',         'm', 'CLUBB Upward Mixing Length Scale')
-    call addfld ('LSCALE_DOWN_CLUBB', (/ 'ilev' /), 'A',       'm', 'CLUBB Downward Mixing Length Scale')
     call addfld ('UPWP_CLUBB',    (/ 'ilev' /), 'A',       'm2/s2', 'Zonal Momentum Flux')
     call addfld ('VPWP_CLUBB',    (/ 'ilev' /), 'A',       'm2/s2', 'Meridional Momentum Flux')
     call addfld ('WP3_CLUBB',    (/ 'ilev' /), 'A',        'm3/s3', 'Third Moment Vertical Velocity')
@@ -995,8 +997,8 @@ end subroutine clubb_init_cnst
        call add_default('QT',               1, ' ')
        call add_default('CONCLD',           1, ' ')
        call add_default('LSCALE_CLUBB',     1, ' ')
-       call add_default('LSCALE_UP_CLUBB',     1, ' ')
-       call add_default('LSCALE_DOWN_CLUBB',     1, ' ')
+       call add_default('LSCALE_UP_CLUBB',  1, ' ')
+       call add_default('LSCALE_DOWN_CLUBB',1, ' ')
     else
        call add_default('CLOUDFRAC_CLUBB',  1, ' ')
        call add_default('CONCLD',           1, ' ')
@@ -1308,13 +1310,18 @@ end subroutine clubb_init_cnst
    real(core_rknd) :: khzm_out(pverp)                  ! eddy diffusivity on momentum grids            [m^2/s]
    real(core_rknd) :: khzt_out(pverp)                  ! eddy diffusivity on thermo grids              [m^2/s]
    real(core_rknd) :: qclvar_out(pverp)                ! cloud water variance                          [kg^2/kg^2]
-   real(core_rknd) :: lscale_out(pverp)                ! CLUBB mixing length scale                     [m]
-   real(core_rknd) :: lscale_up_out(pverp)             ! CLUBB upward mixing length scale              [m]
-   real(core_rknd) :: lscale_down_out(pverp)           ! CLUBB downward mixing length scale            [m]
    real(core_rknd) :: varmu2
    real(core_rknd) :: qrl_clubb(pverp)
    real(core_rknd) :: qrl_zm(pverp)
    real(core_rknd) :: thlp2_rad_out(pverp)
+
+   ! Lscale diagnosed inside CLUBB and passed to the interface subroutine.
+   ! These are defined on thermodynamic levels and have an extra "ghost" level below Earth's surface.
+
+   real(core_rknd) :: lscale_out(pverp)                ! CLUBB mixing length scale                     [m]
+   real(core_rknd) :: lscale_up_out(pverp)             ! CLUBB upward mixing length scale              [m]
+   real(core_rknd) :: lscale_down_out(pverp)           ! CLUBB downward mixing length scale            [m]
+   !---
 
    real(core_rknd), dimension(nparams)  :: clubb_params ! These adjustable CLUBB parameters (C1, C2 ...)
    real(core_rknd), dimension(sclr_dim) :: sclr_tol     ! Tolerance on passive scalar       [units vary]
@@ -1353,10 +1360,15 @@ end subroutine clubb_init_cnst
    real(r8) :: varmu(pcols)
    real(r8) :: zt_out(pcols,pverp)              ! output for the thermo CLUBB grid              [m]
    real(r8) :: zi_out(pcols,pverp)              ! output for momentum CLUBB grid                [m]
-   real(r8) :: lscale(pcols,pverp)              ! CLUBB's mixing length scale, flipped to E3SM's layer indexing [m]
-   real(r8) :: lscale_up(pcols,pverp)           ! CLUBB's upward mixing length scale, flipped to E3SM's layer indexing [m]
-   real(r8) :: lscale_down(pcols,pverp)         ! CLUBB's CLUBB downward mixing length scale, flipped to E3SM's layer indexing [m]
 
+   ! lscale diagnosed inside CLUBB and passed to the interface subroutine.
+   ! The following arrays are used to send values to EAM's history output, hence the vertical indexing
+   ! follows EAM's top-to-bottom convention, and CLUBB's ghost thermodynamic layer is not included.
+
+   real(r8) :: lscale     (pcols,pver)          ! CLUBB's mixing length scale [m]
+   real(r8) :: lscale_up  (pcols,pver)          ! CLUBB's upward mixing length scale [m]
+   real(r8) :: lscale_down(pcols,pver)          ! CLUBB's CLUBB downward mixing length scale [m]
+   !---------------------
 
    real(r8) :: pdf_zm_w_1_inout(pverp)          ! work array for pdf_params_zm%w_1
    real(r8) :: pdf_zm_w_2_inout(pverp)          ! work array for pdf_params_zm%w_2
@@ -2446,9 +2458,6 @@ end subroutine clubb_init_cnst
           cloud_frac(i,k)   = min(real(cloud_frac_inout(pverp-k+1), kind = r8),1._r8)
           rcm_in_layer(i,k) = real(rcm_in_layer_out(pverp-k+1), kind = r8)
           cloud_cover(i,k)  = min(real(cloud_cover_out(pverp-k+1), kind = r8),1._r8)
-          lscale(i,k)       = real(lscale_out(pverp-k+1), kind = r8)
-          lscale_up(i,k)    = real(lscale_up_out(pverp-k+1), kind = r8)
-          lscale_down(i,k)  = real(lscale_down_out(pverp-k+1), kind = r8)
           zt_out(i,k)       = real(zt_g(pverp-k+1), kind = r8)
           zi_out(i,k)       = real(zi_g(pverp-k+1), kind = r8)
           khzm(i,k)         = real(khzm_out(pverp-k+1), kind = r8)
@@ -2465,6 +2474,12 @@ end subroutine clubb_init_cnst
               edsclr_out(k,ixind) = real(edsclr_in(pverp-k+1,ixind), kind = r8)
           enddo
 
+      enddo
+
+      do k=1,pver
+          lscale     (i,k) = real(lscale_out     (pverp-k+1), kind = r8)
+          lscale_up  (i,k) = real(lscale_up_out  (pverp-k+1), kind = r8)
+          lscale_down(i,k) = real(lscale_down_out(pverp-k+1), kind = r8)
       enddo
 
       !  Fill up arrays needed for McICA.  Note we do not want the ghost point,

--- a/components/eam/src/physics/cam/clubb_intr.F90
+++ b/components/eam/src/physics/cam/clubb_intr.F90
@@ -1353,9 +1353,9 @@ end subroutine clubb_init_cnst
    real(r8) :: varmu(pcols)
    real(r8) :: zt_out(pcols,pverp)              ! output for the thermo CLUBB grid              [m]
    real(r8) :: zi_out(pcols,pverp)              ! output for momentum CLUBB grid                [m]
-   real(r8) :: lscale(pcols,pverp)
-   real(r8) :: lscale_up(pcols,pverp)
-   real(r8) :: lscale_down(pcols,pverp)
+   real(r8) :: lscale(pcols,pverp)              ! CLUBB's mixing length scale, flipped to E3SM's layer indexing [m]
+   real(r8) :: lscale_up(pcols,pverp)           ! CLUBB's upward mixing length scale, flipped to E3SM's layer indexing [m]
+   real(r8) :: lscale_down(pcols,pverp)         ! CLUBB's CLUBB downward mixing length scale, flipped to E3SM's layer indexing [m]
 
 
    real(r8) :: pdf_zm_w_1_inout(pverp)          ! work array for pdf_params_zm%w_1

--- a/components/eam/src/physics/cam/lscale_mod.F90
+++ b/components/eam/src/physics/cam/lscale_mod.F90
@@ -4,163 +4,198 @@ module lscale_mod
 
     private
     public :: calculate_lscale
+    public :: lscale_init
 
     contains
 
-subroutine calculate_lscale(state, pbuf)
-    !----------------------------------------------------------------------- 
-    ! 
+subroutine lscale_init()
+   !-----------------------------------------------------------------------
+   ! Purpose:
+   ! Initialization related to the calculation of turbulent length scales
+   ! in the physics driver.
+   !-----------------------------------------------------------------------
+   use cam_history,      only: addfld, add_default
+   
+   ! Add output variables
+
+   call addfld ('LSCALE',     (/ 'ilev' /), 'A', 'm', 'Mixing Length Scale')
+   call addfld ('LSCALE_UP',  (/ 'ilev' /), 'A', 'm', 'Upward Mixing Length Scale')
+   call addfld ('LSCALE_DOWN',(/ 'ilev' /), 'A', 'm', 'Downward Mixing Length Scale')
+
+   call add_default('LSCALE',     1, ' ')
+   call add_default('LSCALE_UP',  1, ' ')
+   call add_default('LSCALE_DOWN',1, ' ')
+
+end subroutine lscale_init
+
+subroutine calculate_lscale(ncol, pcols, pver, pverp,       &
+                            temp_in, pmid_in, qv_in, qc_in, &
+                            zm_in,   zi_in,   tke_in,       &
+                            lscale_out, lscale_up_out, lscale_down_out )
+    !------------------------------------------------------------------------------ 
     ! Purpose: 
     ! Calculate mixing length scales using CLUBB's compute_mixing_length subroutine
-    ! and store the results in physics_state for diagnostic output and future AMR work
-    ! 
-    !-----------------------------------------------------------------------
+    ! and pass the results back to the calling subroutine for diagnostic output
+    ! and future AMR work.
+    !------------------------------------------------------------------------------
     use shr_kind_mod,       only: r8 => shr_kind_r8
-    use ppgrid,             only: pver, pverp ! pverp = pver + 1
-    use physics_types,      only: physics_state
-    use physics_buffer,     only: physics_buffer_desc, pbuf_get_field, pbuf_get_index
-    use constituents,       only: cnst_get_ind
     use physconst,          only: gravit, rair, cpair, latvap, zvir, epsilo
 
     implicit none
 
+    !--------------------
     ! Arguments
-    type(physics_state), intent(inout) :: state
-    type(physics_buffer_desc), pointer :: pbuf(:)
+    !--------------------
+    integer, intent(in) :: ncol, pcols, pver, pverp     ! pverp = pver + 1
 
-    real(r8), parameter :: p0_clubb = 100000._r8      ! reference pressure (Pa)
+    real(r8), intent(in)  :: temp_in(pcols,pver)   ! temperature [K] at layer midpoints
+    real(r8), intent(in)  :: pmid_in(pcols,pver)   ! pressure [Pa] at layer midpoints
+    real(r8), intent(in)  ::   qv_in(pcols,pver)   ! water vapor mixing ratio [kg/kg] at layer midpoints
+    real(r8), intent(in)  ::   qc_in(pcols,pver)   ! cloud liquid mixing ratio [kg/kg] at layer midpoints
+    real(r8), intent(in)  ::   zm_in(pcols,pver)   ! geopotential height [m] at layer midpoints
+    real(r8), intent(in)  ::   zi_in(pcols,pverp)  ! geopotential height [m] at layer interfaces
+    real(r8), intent(in)  ::  tke_in(pcols,pverp)  ! turbulent kinetic energy [m2/s2] at layer interfaces
 
-    ! Variables for compute_mixing_length
-    real(r8), allocatable :: zt(:)         ! height at thermodynamic levels
-    real(r8), allocatable :: zm(:)         ! height at momentum levels
-    real(r8), allocatable :: dzm(:)        ! grid spacing at momentum levels
-    real(r8), allocatable :: invrs_dzm(:)  ! 1/dzm
+    real(r8), intent(out) :: lscale_out     (pcols,pverp)   ! turbulent mixing length scale [m]
+    real(r8), intent(out) :: lscale_up_out  (pcols,pverp)   ! turbulent mixing length scale, upward [m]
+    real(r8), intent(out) :: lscale_down_out(pcols,pverp)   ! turbulent mixing length scale, downward [m]
 
-    real(r8), allocatable :: thvm(:)       ! virtual potential temperature
-    real(r8), allocatable :: thlm(:)       ! liquid water potential temperature
-    real(r8), allocatable :: rtm(:)        ! total water mixing ratio
-    real(r8), allocatable :: em(:)         ! turbulent kinetic energy
-    real(r8), allocatable :: p_in_Pa(:)    ! pressure in Pa
-    real(r8), allocatable :: exner(:)      ! exner function
-    real(r8), allocatable :: thv_ds(:)     ! dry static virtual potential temperature
+    !-----------------------------------------------------------------------------------------
+    ! Local arrays. Their shape and direction of indexing follow CLUBB:
+    !  - Variables defined on thermodynamic levels (corresponding to E3SM's layer midpoints)
+    !    have a extra ghost level below ground/Earth surface;
+    !  - Level indices start from the surface and increase upward.
+    !-----------------------------------------------------------------------------------------
+    ! Input arrays of CLUBB's compute_mixing_length subroutine
 
-    ! CLUBB output arrays
-    real(r8), allocatable :: lscale_out(:)
-    real(r8), allocatable :: lscale_up_out(:) 
-    real(r8), allocatable :: lscale_down_out(:)
+    real(r8) :: zt       (pverp)  ! height at thermodynamic levels
+    real(r8) :: zm       (pverp)  ! height at momentum levels
+    real(r8) :: dzm      (pverp)  ! grid spacing at momentum levels
+    real(r8) :: invrs_dzm(pverp)  ! 1/dzm
 
-    ! Physics buffer fields
-    real(r8), pointer :: tke(:,:)           ! turbulent kinetic energy
+    real(r8) :: thvm     (pverp)  ! virtual potential temperature
+    real(r8) :: thlm     (pverp)  ! liquid water potential temperature
+    real(r8) :: rtm      (pverp)  ! total water mixing ratio
+    real(r8) :: em       (pverp)  ! turbulent kinetic energy
+    real(r8) :: p_in_Pa  (pverp)  ! pressure in Pa
+    real(r8) :: exner    (pverp)  ! exner function
+    real(r8) :: thv_ds   (pverp)  ! dry static virtual potential temperature
 
-    ! Local variables
-    integer :: i, k, kflip, ncol
-    integer :: ixq, ixcldliq ! constituent indices
+    ! Input arrays of CLUBB's compute_mixing_length subroutine
+
+    real(r8) :: lscale_tmp     (pverp)
+    real(r8) :: lscale_up_tmp  (pverp) 
+    real(r8) :: lscale_down_tmp(pverp)
+
+    !--------------------
+    ! Local scalars
+    !--------------------
+    integer :: ii, kk, kflip    ! array indices
+
     real(r8) :: temp_k
     real(r8) :: theta_v
     real(r8) :: press_pa
     real(r8) :: qv, qc
     real(r8) :: exner_clubb
-   
-    ncol = state%ncol
 
-    ! Get constituent indices
-    call cnst_get_ind('Q', ixq)
-    call cnst_get_ind('CLDLIQ', ixcldliq)
-    ! Get physics buffer fields
-    call pbuf_get_field(pbuf, pbuf_get_index('tke'), tke)
+    real(r8), parameter :: p0_clubb = 100000._r8      ! reference pressure (Pa)
 
-    ! Allocate 1D arrays for single column processing
-    allocate(zt(pverp))
-    allocate(zm(pverp))
-    allocate(dzm(pverp))
-    allocate(invrs_dzm(pverp))
-
-    allocate(thvm(pverp))
-    allocate(thlm(pverp))
-    allocate(rtm(pverp))
-    allocate(em(pverp))
-    allocate(p_in_Pa(pverp))
-    allocate(exner(pverp))
-    allocate(thv_ds(pverp))
-
-    allocate(lscale_out(pverp))
-    allocate(lscale_up_out(pverp))
-    allocate(lscale_down_out(pverp))
-
+    !--------------------------------------
     ! Process each column separately
-    do i = 1, ncol
-       ! Prepare input variables for this column
-       ! could also have gotten them from pbuf,
-       ! but following clubb_tend_cam in clubb_intr.F90 here
-       do k = 1, pver
-          ! for flipping to CLUBB ordering
-          kflip = pver - k + 1
-          ! thermodynamic-level variables
-          temp_k = state%t(i, kflip)
-          press_pa = state%pmid(i, kflip)
+    !--------------------------------------
+    do ii = 1, ncol
+
+       !====================================================
+       ! 1. Prepare input variables for this column
+       !    following clubb_tend_cam in clubb_intr.F90.
+       !====================================================
+       do kk = 1, pver
+
+          !------------------------------------
+          ! 1.1 Thermodynamic-level variables
+          !------------------------------------
+          kflip = pver - kk + 1   ! for flipping to CLUBB ordering
+
+          temp_k = temp_in(ii, kflip)
+          press_pa = pmid_in(ii, kflip)
           exner_clubb = (p0_clubb/press_pa)**(rair/cpair)
-          qv = state%q(i, kflip, ixq)  ! water vapor
-          qc = state%q(i, kflip, ixcldliq)  ! cloud liquid
+
+          qv = qv_in(ii, kflip)  ! water vapor
+          qc = qc_in(ii, kflip)  ! cloud liquid
+
           ! virtual potential temperature per CLUBB
           theta_v = temp_k*exner_clubb*(1.0_r8 + zvir*qv - qc)
 
-          rtm(k+1) = qv + qc ! total water mixing ratio per CLUBB
-          thlm(k+1) = (temp_k - (latvap/cpair)*qc)*exner_clubb
-          p_in_Pa(k+1) = press_pa
-          exner(k+1) = 1.0_r8 / exner_clubb
+          rtm(kk+1) = qv + qc ! total water mixing ratio per CLUBB
+          thlm(kk+1) = (temp_k - (latvap/cpair)*qc)*exner_clubb
+          p_in_Pa(kk+1) = press_pa
+          exner(kk+1) = 1.0_r8 / exner_clubb
+
           ! note here thv_ds is assigned actual moist theta_v 
           ! following what is done in clubb_tend_cam in clubb_intr.F90
-          thv_ds(k+1) = theta_v
+          thv_ds(kk+1) = theta_v
+
           ! thvm is then calculated again in advance_clubb_core
           ! as follows:
-          thvm(k+1) = thlm(k+1) + ((1.0_r8 - epsilo)/epsilo) * thv_ds(k+1) *rtm(k+1) &
-                        + (latvap/(cpair*exner(k+1)) - (1.0_r8/epsilo) *thv_ds(k+1))*qc
+          thvm(kk+1) = thlm(kk+1) + ((1.0_r8 - epsilo)/epsilo) * thv_ds(kk+1) *rtm(kk+1) &
+                        + (latvap/(cpair*exner(kk+1)) - (1.0_r8/epsilo) *thv_ds(kk+1))*qc
+
           ! thermodynamic-level heights
-          zt(k+1) = state%zm(i, kflip) - state%zi(i, pver+1)
-          ! momentum-level variables
-          em(k) = tke(i, pverp-k+1)
-          ! momentum-level heights
-          zm(k) = state%zi(i,pverp-k+1)-state%zi(i,pver+1)
+          zt(kk+1) = zm_in(ii, kflip) - zi_in(ii, pver+1)
+
+          !-------------------------------
+          ! 1.2 Momentum-level variables
+          !-------------------------------
+          em(kk) = tke_in(ii,pverp-kk+1)                    ! TKE
+          zm(kk) =  zi_in(ii,pverp-kk+1) - zi_in(ii,pver+1) ! geopot. height above sfc (of layer interfaces) 
+
        end do
 
-       ! fill in for the first level of zt below surface
-       zt(1) = -1.0_r8 * zt(2)
-       exner(1) = exner(2)
+       !------------------------------------------------------------------------------------
+       ! 1.3 For variables on zt levels (layer midpoints), fill in values for ghost level.
+       !------------------------------------------------------------------------------------
+            zt(1) = -1.0_r8 * zt(2)
+         exner(1) =   exner(2)
        p_in_Pa(1) = p_in_Pa(2)
-       rtm(1) = rtm(2)
-       thlm(1) = thlm(2)
-       thv_ds(1) = thv_ds(2)
-       thvm(1) = thvm(2)
-       ! tke is asumed to be on momentum levels
-       ! simply copying whatever is at the topmost momentum level
-       em(pverp) = tke(i, 1)
-       ! pverp is the topmost momentum level
-       zm(pverp) = state%zi(i,1)-state%zi(i,pver+1)
-       do k = 1, pver
-         dzm(k) = zt(k+1) - zt(k)
-         invrs_dzm(k) = 1.0_r8 / dzm(k)
+           rtm(1) =     rtm(2)
+          thlm(1) =    thlm(2)
+        thv_ds(1) =  thv_ds(2)
+          thvm(1) =    thvm(2)
+
+       !------------------------------------------------------------------------------------
+       ! 1.5 For variables on zm levels (layer interfaces), set values at model top.
+       !------------------------------------------------------------------------------------
+       em(pverp) = tke_in(ii,1)
+       zm(pverp) =  zi_in(ii,1) - zi_in(ii,pver+1)
+
+       !------------------------------------------------------------------------------------
+       ! 1.6 Calculate dz and 1/dz.
+       !------------------------------------------------------------------------------------
+       do kk = 1, pver
+               dzm(kk) = zt(kk+1) - zt(kk)
+         invrs_dzm(kk) = 1.0_r8 / dzm(kk)
        end do
-       dzm(pverp) = dzm(pver)  ! does not matter much what we put here
+             dzm(pverp) =       dzm(pver)  ! does not matter much what we put here
        invrs_dzm(pverp) = invrs_dzm(pver)
 
-       ! Call CLUBB's compute_mixing_length for this column
+       !========================================================
+       ! 2. Call CLUBB's compute_mixing_length for this column
+       !========================================================
        call compute_mixing_length_standalone( &
          pverp, zt, zm, dzm, invrs_dzm, & 
          thvm, thlm, rtm, em, p_in_Pa, exner, thv_ds, &
-         lscale_out, lscale_up_out, lscale_down_out )
+         lscale_tmp, lscale_up_tmp, lscale_down_tmp )
 
-       ! Store results in physics_state (convert back to r8)
-       do k = 1, pverp
-          state%lscale(i, k) = lscale_out(pverp-k+1)  ! flip back to match EAM ordering
-          state%lscale_up(i, k) = lscale_up_out(pverp-k+1)
-          state%lscale_down(i, k) = lscale_down_out(pverp-k+1)
+       !========================================================
+       ! 3. Flip the vertical indexing for output to host model
+       !========================================================
+       do kk = 1, pverp
+          lscale_out     (ii,kk) = lscale_tmp     (pverp-kk+1)
+          lscale_up_out  (ii,kk) = lscale_up_tmp  (pverp-kk+1)
+          lscale_down_out(ii,kk) = lscale_down_tmp(pverp-kk+1)
        end do
-    end do
 
-    ! Clean up
-    deallocate(zt, zm, dzm, invrs_dzm)
-    deallocate(thvm, thlm, rtm, em, p_in_Pa, exner, thv_ds)
-    deallocate(lscale_out, lscale_up_out, lscale_down_out)
+    end do ! ii = 1,ncol
 
 end subroutine calculate_lscale
 

--- a/components/eam/src/physics/cam/lscale_mod.F90
+++ b/components/eam/src/physics/cam/lscale_mod.F90
@@ -18,9 +18,9 @@ subroutine lscale_init()
    
    ! Add output variables
 
-   call addfld ('LSCALE',     (/ 'ilev' /), 'A', 'm', 'Mixing Length Scale')
-   call addfld ('LSCALE_UP',  (/ 'ilev' /), 'A', 'm', 'Upward Mixing Length Scale')
-   call addfld ('LSCALE_DOWN',(/ 'ilev' /), 'A', 'm', 'Downward Mixing Length Scale')
+   call addfld ('LSCALE',     (/ 'lev' /), 'A', 'm', 'Mixing Length Scale')
+   call addfld ('LSCALE_UP',  (/ 'lev' /), 'A', 'm', 'Upward Mixing Length Scale')
+   call addfld ('LSCALE_DOWN',(/ 'lev' /), 'A', 'm', 'Downward Mixing Length Scale')
 
    call add_default('LSCALE',     1, ' ')
    call add_default('LSCALE_UP',  1, ' ')
@@ -48,6 +48,8 @@ subroutine calculate_lscale(ncol, pcols, pver, pverp,       &
     !--------------------
     integer, intent(in) :: ncol, pcols, pver, pverp     ! pverp = pver + 1
 
+    ! Meteorological fields needed to diagnose Lscale.
+
     real(r8), intent(in)  :: temp_in(pcols,pver)   ! temperature [K] at layer midpoints
     real(r8), intent(in)  :: pmid_in(pcols,pver)   ! pressure [Pa] at layer midpoints
     real(r8), intent(in)  ::   qv_in(pcols,pver)   ! water vapor mixing ratio [kg/kg] at layer midpoints
@@ -56,9 +58,11 @@ subroutine calculate_lscale(ncol, pcols, pver, pverp,       &
     real(r8), intent(in)  ::   zi_in(pcols,pverp)  ! geopotential height [m] at layer interfaces
     real(r8), intent(in)  ::  tke_in(pcols,pverp)  ! turbulent kinetic energy [m2/s2] at layer interfaces
 
-    real(r8), intent(out) :: lscale_out     (pcols,pverp)   ! turbulent mixing length scale [m]
-    real(r8), intent(out) :: lscale_up_out  (pcols,pverp)   ! turbulent mixing length scale, upward [m]
-    real(r8), intent(out) :: lscale_down_out(pcols,pverp)   ! turbulent mixing length scale, downward [m]
+    ! Lscale and its upward and downward components, defined at layer midpoints
+
+    real(r8), intent(out) :: lscale_out     (pcols,pver)   ! turbulent mixing length scale [m]
+    real(r8), intent(out) :: lscale_up_out  (pcols,pver)   ! turbulent mixing length scale, upward [m]
+    real(r8), intent(out) :: lscale_down_out(pcols,pver)   ! turbulent mixing length scale, downward [m]
 
     !-----------------------------------------------------------------------------------------
     ! Local arrays. Their shape and direction of indexing follow CLUBB:
@@ -81,7 +85,9 @@ subroutine calculate_lscale(ncol, pcols, pver, pverp,       &
     real(r8) :: exner    (pverp)  ! exner function
     real(r8) :: thv_ds   (pverp)  ! dry static virtual potential temperature
 
-    ! Input arrays of CLUBB's compute_mixing_length subroutine
+    ! Output arrays of CLUBB's compute_mixing_length subroutine.
+    ! These are defined at layer midpoints (CLUBB's thermodynamic levels)
+    ! and have a "ghost" level below Earth's surface.
 
     real(r8) :: lscale_tmp     (pverp)
     real(r8) :: lscale_up_tmp  (pverp) 
@@ -187,9 +193,10 @@ subroutine calculate_lscale(ncol, pcols, pver, pverp,       &
          lscale_tmp, lscale_up_tmp, lscale_down_tmp )
 
        !========================================================
-       ! 3. Flip the vertical indexing for output to host model
+       ! 3. Flip the vertical indexing for output to host model;
+       !    ignore the ghost level below Earth's surface.
        !========================================================
-       do kk = 1, pverp
+       do kk = 1, pver
           lscale_out     (ii,kk) = lscale_tmp     (pverp-kk+1)
           lscale_up_out  (ii,kk) = lscale_up_tmp  (pverp-kk+1)
           lscale_down_out(ii,kk) = lscale_down_tmp(pverp-kk+1)

--- a/components/eam/src/physics/cam/physics_types.F90
+++ b/components/eam/src/physics/cam/physics_types.F90
@@ -97,10 +97,7 @@ module physics_types
           pintdry, &! interface pressure dry (Pa) 
           lnpint,  &! ln(pint)
           lnpintdry,&! log interface pressure dry (Pa) 
-          zi,      &! geopotential height above surface at interfaces (m)
-          lscale,  &! mixing length scale (m)
-          lscale_up, &! upward mixing length scale (m)
-          lscale_down ! downward mixing length scale (m)
+          zi        ! geopotential height above surface at interfaces (m)
 
      real(r8), dimension(:),allocatable          :: &
           te_ini,  &! vertically integrated total energy of initial state
@@ -1438,14 +1435,6 @@ end subroutine physics_ptend_copy
        end do
     end do
 
-    do k = 1, pverp
-       do i = 1, ncol
-          state_out%lscale(i,k)    = state_in%lscale(i,k)
-          state_out%lscale_up(i,k) = state_in%lscale_up(i,k)
-          state_out%lscale_down(i,k) = state_in%lscale_down(i,k)
-       end do
-    end do
-
 
        do i = 1, ncol
           state_out%psdry(i)  = state_in%psdry(i) 
@@ -1740,15 +1729,6 @@ subroutine physics_state_alloc(state,lchnk,psetcols)
   allocate(state%zi(psetcols,pver+1), stat=ierr)
   if ( ierr /= 0 ) call endrun('physics_state_alloc error: allocation error for state%zi')
   
-  allocate(state%lscale(psetcols,pver+1), stat=ierr)
-  if ( ierr /= 0 ) call endrun('physics_state_alloc error: allocation error for state%lscale')
-  
-  allocate(state%lscale_up(psetcols,pver+1), stat=ierr)
-  if ( ierr /= 0 ) call endrun('physics_state_alloc error: allocation error for state%lscale_up')
-  
-  allocate(state%lscale_down(psetcols,pver+1), stat=ierr)
-  if ( ierr /= 0 ) call endrun('physics_state_alloc error: allocation error for state%lscale_down')
-  
   allocate(state%te_ini(psetcols), stat=ierr)
   if ( ierr /= 0 ) call endrun('physics_state_alloc error: allocation error for state%te_ini')
   
@@ -1880,9 +1860,6 @@ subroutine physics_state_alloc(state,lchnk,psetcols)
   state%lnpint(:,:) = inf
   state%lnpintdry(:,:) = inf
   state%zi(:,:) = inf
-  state%lscale(:,:) = inf
-  state%lscale_up(:,:) = inf
-  state%lscale_down(:,:) = inf
       
   state%te_ini(:) = inf
   state%te_cur(:) = inf
@@ -2016,15 +1993,6 @@ subroutine physics_state_dealloc(state)
   
   deallocate(state%zi, stat=ierr)
   if ( ierr /= 0 ) call endrun('physics_state_dealloc error: deallocation error for state%zi')
-
-  deallocate(state%lscale, stat=ierr)
-  if ( ierr /= 0 ) call endrun('physics_state_dealloc error: deallocation error for state%lscale')
-  
-  deallocate(state%lscale_up, stat=ierr)
-  if ( ierr /= 0 ) call endrun('physics_state_dealloc error: deallocation error for state%lscale_up')
-  
-  deallocate(state%lscale_down, stat=ierr)
-  if ( ierr /= 0 ) call endrun('physics_state_dealloc error: deallocation error for state%lscale_down')
 
   deallocate(state%te_ini, stat=ierr)
   if ( ierr /= 0 ) call endrun('physics_state_dealloc error: deallocation error for state%te_ini')

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -256,7 +256,6 @@ subroutine phys_register
        
        ! Register SHOC_SGS here
        if (do_shoc_sgs) call shoc_register_e3sm()
-       
 
        call pbuf_add_field('PREC_STR',  'physpkg',dtype_r8,(/pcols/),prec_str_idx)
        call pbuf_add_field('SNOW_STR',  'physpkg',dtype_r8,(/pcols/),snow_str_idx)
@@ -291,14 +290,6 @@ subroutine phys_register
 
        ! register chemical constituents including aerosols ...
        call chem_register(species_class)
-
-      ! Register CLUBB mixing length scale diagnostic variables
-      call addfld ('LSCALE',    (/ 'ilev' /), 'A', 'm', 'Mixing Length Scale')
-      call addfld ('LSCALE_UP', (/ 'ilev' /), 'A', 'm', 'Upward Mixing Length Scale')
-      call addfld ('LSCALE_DOWN',(/ 'ilev' /), 'A', 'm', 'Downward Mixing Length Scale')
-      call add_default('LSCALE',     1, ' ')
-      call add_default('LSCALE_UP',  1, ' ')
-      call add_default('LSCALE_DOWN',1, ' ')
 
        ! NB: has to be after chem_register to use tracer names
        ! Fields for gas chemistry tracers
@@ -786,6 +777,7 @@ subroutine phys_init( phys_state, phys_tend, pbuf2d, cam_out )
     use majorsp_diffusion,  only: mspd_init   ! Initialization of major species diffusion module (WACCM-X)
     use clubb_intr,         only: clubb_ini_cam
     use shoc_intr,          only: shoc_init_e3sm
+    use lscale_mod,         only: lscale_init
     use sslt_rebin,         only: sslt_rebin_init
     use tropopause,         only: tropopause_init
     use solar_data,         only: solar_data_init
@@ -980,6 +972,8 @@ subroutine phys_init( phys_state, phys_tend, pbuf2d, cam_out )
     
     ! initiate SHOC within E3SM
     if (do_shoc_sgs) call shoc_init_e3sm(pbuf2d,dp1)
+
+    call lscale_init
 
     call qbo_init
 
@@ -2386,6 +2380,14 @@ subroutine tphysbc (ztodt,               &
     real(r8), pointer, dimension(:) :: water_vap_ac_2d   ! Vertically integrated water vapor
     real(r8) :: CIDiff(pcols)            ! Difference in vertically integrated static energy
 
+
+    ! For diagnosing lscale
+    real(r8),pointer :: tke(:,:)
+    integer  :: ixq, ixcldliq
+    real(r8) :: lscale     (pcols,pverp)
+    real(r8) :: lscale_up  (pcols,pverp)
+    real(r8) :: lscale_down(pcols,pverp)
+
     !HuiWan (2014/15): added for a short-term time step convergence test ++ 
     logical :: l_bc_energy_fix
     logical :: l_dry_adj
@@ -2855,14 +2857,23 @@ end if
     end if
 !!== KZ_WATCON 
 
-            ! calculate L_scale using subroutines taken from CLUBB
-            ! for output and for future AMR work - H. Xiao
-            call calculate_lscale(state, pbuf)
+           !=======================================================
+           ! calculate L_scale using subroutines taken from CLUBB
+           ! for output and for future AMR work - H. Xiao & H. Wan
+           !=======================================================
+           call cnst_get_ind('Q',      ixq)
+           call cnst_get_ind('CLDLIQ', ixcldliq)
+           call pbuf_get_field(pbuf, pbuf_get_index('tke'), tke)
 
-            ! Output CLUBB mixing length scale diagnostic variables
-            call outfld('LSCALE',    state%lscale,      ncol, lchnk)
-            call outfld('LSCALE_UP', state%lscale_up,   ncol, lchnk)
-            call outfld('LSCALE_DOWN', state%lscale_down, ncol, lchnk)
+           call calculate_lscale(ncol,     pcols,      pver,             pverp,                 &! in
+                                 state%t,  state%pmid, state%q(:,:,ixq), state%q(:,:,ixcldliq), &! in
+                                 state%zm, state%zi,   tke,                                     &! in
+                                 lscale, lscale_up, lscale_down                                 )! out
+
+           ! Send the diagnosed lscales to history output
+           call outfld('LSCALE',      lscale,      pcols, lchnk)
+           call outfld('LSCALE_UP',   lscale_up,   pcols, lchnk)
+           call outfld('LSCALE_DOWN', lscale_down, pcols, lchnk)
 
              ! =====================================================
              !    CLUBB call (PBL, shallow convection, macrophysics)

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -2384,9 +2384,9 @@ subroutine tphysbc (ztodt,               &
     ! For diagnosing lscale
     real(r8),pointer :: tke(:,:)
     integer  :: ixq, ixcldliq
-    real(r8) :: lscale     (pcols,pverp)
-    real(r8) :: lscale_up  (pcols,pverp)
-    real(r8) :: lscale_down(pcols,pverp)
+    real(r8) :: lscale     (pcols,pver)
+    real(r8) :: lscale_up  (pcols,pver)
+    real(r8) :: lscale_down(pcols,pver)
 
     !HuiWan (2014/15): added for a short-term time step convergence test ++ 
     logical :: l_bc_energy_fix


### PR DESCRIPTION
Two main changes are included in this PR:

1. Refactor:

   - The subroutine `calculate_lscale` now operates on plain arrays instead of EAM's derived types (state and pbuf).
   - The diagnosed Lscales are taken out of the state variable and declared as local array in subroutine `tphysbc` for now.

These changes were motivated by the reasoning that in an AMR setting, we will be calculating Lscales on the refined/adjusted grid; at this point, it's not yet clear what kind data structures will be used, hence for now, we make `lscale_mod.F90` more plain and general.

2. Array shape:

    For (i) the Lscale arrays "seen" by EAM's physics driver and (ii) the `LSCALE*_CLUBB` variables written into history files, CLUBB's "ghost" level below Earth's surface is removed. This is meant to help clarify that Lscale is defined at layer midpoints.