### PR TITLE
CLUBB/SHOC "nadv" subcycle output

### DIFF
--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -4148,6 +4148,14 @@ Default: Set by namelist
 
 <!-- Diagnostics -->
 
+<entry id="turb_nadv_out_nstep" type="integer"  category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Number of turbulence parameterization's internal substeps
+for which output will be added to history files.
+0 means no such output.
+Default: 0
+</entry>
+
 <entry id="history_amwg" type="logical"  category="diagnostics"
        group="phys_ctl_nl" valid_values="" >
 Produce output for the AMWG diagnostic package.

--- a/components/eam/src/physics/cam/clubb_intr.F90
+++ b/components/eam/src/physics/cam/clubb_intr.F90
@@ -636,6 +636,9 @@ end subroutine clubb_init_cnst
 #endif
 
     use physics_buffer,         only: pbuf_get_index, pbuf_set_field, physics_buffer_desc
+    use iop_data_mod,           only: single_column
+    use cam_abortutils,         only: endrun
+
     implicit none
     !  Input Variables
     type(physics_buffer_desc), pointer :: pbuf2d(:,:)
@@ -667,6 +670,14 @@ end subroutine clubb_init_cnst
     real(core_rknd)  :: zt_g(pverp)                        ! Height dummy array
     real(core_rknd)  :: zi_g(pverp)                        ! Height dummy array
 
+    ! For writing out (to history files) the values from substeps used
+    ! by CLUBB w.r.t. the mac-mic timesteps
+
+    integer :: turb_nadv_out_nstep     ! # of substeps to write out
+    integer :: iadv                    ! substep index
+    character(len=8) :: numstr         ! a string like "_0001" to append to variable names in history files
+    !-----------------------------------
+
 
     !----- Begin Code -----
     !$OMP PARALLEL
@@ -694,6 +705,7 @@ end subroutine clubb_init_cnst
     call phys_getopts(prog_modal_aero_out=prog_modal_aero, &
                       history_amwg_out=history_amwg, &
                       history_clubb_out=history_clubb,&
+                      turb_nadv_out_nstep_out = turb_nadv_out_nstep, &
                       liqcf_fix_out   = liqcf_fix)
 
     !  Select variables to apply tendencies back to CAM
@@ -932,6 +944,34 @@ end subroutine clubb_init_cnst
     call addfld ('VMAGDP',        horiz_only,     'A',             '-', 'ZM gustiness enhancement')
     call addfld ('VMAGCL',        horiz_only,     'A',             '-', 'CLUBB gustiness enhancement')
     call addfld ('TPERTBLT',        horiz_only,     'A',             'K', 'perturbation temperature at PBL top')
+
+    ! Add output variables from CLUBB's internal substeps
+
+    if (turb_nadv_out_nstep.gt.0) then
+
+       if (single_column) then
+
+          do iadv = 1,turb_nadv_out_nstep
+
+             write(numstr,'(a1,i4.4)') '_',iadv
+
+             call addfld(    'QLIQ'//trim(adjustl(numstr)), (/'lev'/), 'A', 'kg/kg', 'liquid water mixing ratio')
+             call addfld(  'THETAL'//trim(adjustl(numstr)), (/'lev'/), 'A', 'K',     'liquid water potential temperature')
+             call addfld( 'CLDFRAC'//trim(adjustl(numstr)), (/'lev'/), 'A', '1',     'cloud fraction')
+
+             call add_default(    'QLIQ'//trim(adjustl(numstr)), 1, ' ') 
+             call add_default(  'THETAL'//trim(adjustl(numstr)), 1, ' ') 
+             call add_default( 'CLDFRAC'//trim(adjustl(numstr)), 1, ' ') 
+
+          end do
+
+       else
+          call endrun('clubb_ini_cam: when CLUBB is used as the turbulence parameterization,'// &
+                      'turb_nadv_out_nstep.gt.0 can only be used in single-column mode.'        )
+       end if
+    end if
+    !-------------
+
 
     !  Initialize statistics, below are dummy variables
     dum1 = 300._r8
@@ -1216,6 +1256,11 @@ end subroutine clubb_init_cnst
    integer :: icnt, clubbtop
 
    real(r8) :: frac_limit, ic_limit
+
+   ! for single-column mode only:
+   character(len=8) :: numstr         ! a string like "_0001" that corresponds to a single value of CLUBB's timestep counter t
+   integer :: turb_nadv_out_nstep     ! # of CLUBB's time steps to write out fields for
+   !-----
 
   !=====================================================================================
   ! The variables defined as core_rknd is required by the advance_clubb_core_api()
@@ -1570,6 +1615,7 @@ end subroutine clubb_init_cnst
    !-----------------------------------------------------------------------------------------------!
    !-----------------------------------------------------------------------------------------------!
    !-----------------------------------------------------------------------------------------------!
+   call phys_getopts(turb_nadv_out_nstep_out = turb_nadv_out_nstep)
 
    write(char_macmic_it,'(i2.2)') macmic_it
 
@@ -2385,6 +2431,21 @@ end subroutine clubb_init_cnst
           !  output arrays to make them conformable to CAM output
           if (l_stats) call stats_end_timestep_clubb(lchnk,i,out_zt,out_zm,&
                                                      out_radzt,out_radzm,out_sfc)
+
+          !---------------------------------------------------------------------------------------------------
+          ! Only in single-column mode: Send values to history output.
+          ! The outfld calls are placed here in order to capture field values inside 'adv_clubb_core_ts_loop'.
+          ! For multi-column/global simulations, outfld calls should not be placed inside the column loop.
+          !---------------------------------------------------------------------------------------------------
+          if (single_column.and.(t.le.turb_nadv_out_nstep)) then
+
+             write(numstr,'(a1,i4.4)') '_',t
+  
+             call outfld(    'QLIQ'//trim(adjustl(numstr)),        rcm_inout(pverp:2:-1),ncol,lchnk)
+             call outfld(  'THETAL'//trim(adjustl(numstr)),          thlm_in(pverp:2:-1),ncol,lchnk)
+             call outfld( 'CLDFRAC'//trim(adjustl(numstr)), cloud_frac_inout(pverp:2:-1),ncol,lchnk)
+          end if
+          !--------------------
 
       enddo  ! end time loop
       call t_stopf('adv_clubb_core_ts_loop')

--- a/components/eam/src/physics/cam/phys_control.F90
+++ b/components/eam/src/physics/cam/phys_control.F90
@@ -77,6 +77,11 @@ logical           :: use_subcol_microp    = .false.    ! if .true. then use sub-
 
 logical           :: atm_dep_flux         = .true.     ! true => deposition fluxes will be provided
                                                        ! to the coupler
+
+integer           :: turb_nadv_out_nstep  = 0          ! # of turb parameterization's internal substeps
+                                                       ! for which output will be added to history files.
+                                                       ! 0 means no such output.
+
 logical           :: history_amwg         = .true.     ! output the variables used by the AMWG diag package
 logical           :: history_verbose      = .false.    ! produce verbose output by default
 logical           :: history_vdiag        = .false.    ! output the variables used by the AMWG variability diag package
@@ -232,7 +237,7 @@ subroutine phys_ctl_readnl(nlfile)
       MMF_microphysics_scheme, MMF_orientation_angle, use_MMF, use_ECPP, &
       use_MMF_VT, MMF_VT_wn_max, use_MMF_ESMT, &
       use_crm_accel, crm_accel_factor, crm_accel_uv, &
-      use_subcol_microp, atm_dep_flux, history_amwg, history_verbose, history_vdiag, &
+      use_subcol_microp, atm_dep_flux, turb_nadv_out_nstep, history_amwg, history_verbose, history_vdiag, &
       get_presc_aero_data,history_aerosol, history_aero_optics, &
       is_output_interactive_volc, &
       history_eddy, history_budget,  history_budget_histfile_num, history_waccm, &
@@ -318,6 +323,7 @@ subroutine phys_ctl_readnl(nlfile)
    call mpibcast(crm_accel_uv,                    1 , mpilog,  0, mpicom)
    call mpibcast(use_subcol_microp,               1 , mpilog,  0, mpicom)
    call mpibcast(atm_dep_flux,                    1 , mpilog,  0, mpicom)
+   call mpibcast(turb_nadv_out_nstep,             1 , mpiint,  0, mpicom)
    call mpibcast(history_amwg,                    1 , mpilog,  0, mpicom)
    call mpibcast(history_verbose,                 1 , mpilog,  0, mpicom)
    call mpibcast(history_vdiag,                   1 , mpilog,  0, mpicom)
@@ -583,6 +589,7 @@ end function waccmx_is
 subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, & 
                         microp_scheme_out, &
                         radiation_scheme_out, use_subcol_microp_out, atm_dep_flux_out, &
+                        turb_nadv_out_nstep_out, &
                         history_amwg_out, history_verbose_out, history_vdiag_out, &
                         get_presc_aero_data_out,&
                         is_output_interactive_volc_out,&        
@@ -644,6 +651,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
    logical,           intent(out), optional :: crm_accel_uv_out
    logical,           intent(out), optional :: use_subcol_microp_out
    logical,           intent(out), optional :: atm_dep_flux_out
+   integer,           intent(out), optional :: turb_nadv_out_nstep_out
    logical,           intent(out), optional :: history_amwg_out
    logical,           intent(out), optional :: history_verbose_out
    logical,           intent(out), optional :: history_vdiag_out
@@ -777,6 +785,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
    if ( present(UCIgaschmbudget_2D_L3_e_out) ) UCIgaschmbudget_2D_L3_e_out = UCIgaschmbudget_2D_L3_e
    if ( present(UCIgaschmbudget_2D_L4_s_out) ) UCIgaschmbudget_2D_L4_s_out = UCIgaschmbudget_2D_L4_s
    if ( present(UCIgaschmbudget_2D_L4_e_out) ) UCIgaschmbudget_2D_L4_e_out = UCIgaschmbudget_2D_L4_e
+   if ( present(turb_nadv_out_nstep_out ) ) turb_nadv_out_nstep_out  = turb_nadv_out_nstep
    if ( present(history_amwg_out        ) ) history_amwg_out         = history_amwg
    if ( present(history_verbose_out     ) ) history_verbose_out         = history_verbose
    if ( present(history_vdiag_out       ) ) history_vdiag_out        = history_vdiag

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -221,6 +221,7 @@ end subroutine shoc_init
 ! Host models should call the following routine to call SHOC
 
 subroutine shoc_main ( &
+     turb_nadv_out_nstep, lchnk, &        ! Input
      shcol, nlev, nlevi, dtime, nadv, &   ! Input
      host_dx, host_dy,thv, &              ! Input
      zt_grid,zi_grid,pres,presi,pdel,&    ! Input
@@ -246,9 +247,15 @@ subroutine shoc_main ( &
     use shoc_iso_f, only: shoc_main_f
 #endif
 
+  use cam_history,    only: outfld
+
   implicit none
 
 ! INPUT VARIABLES
+
+  integer, intent(in) :: turb_nadv_out_nstep ! # of time steps (in this subr.) to write out fields for
+  integer, intent(in) :: lchnk               ! chunk ID related to the host model's domain decomposition
+
   ! number of SHOC columns in the array
   integer, intent(in) :: shcol
   ! number of levels [-]
@@ -372,6 +379,9 @@ subroutine shoc_main ( &
 
   ! time counter
   integer :: t
+
+  ! a string like "_0001" that corresponds to a single value of the time counter
+  character(len=8) :: numstr
 
   ! air density on thermo grid [kg/m3]
   real(rtype) :: rho_zt(shcol,nlev)
@@ -541,6 +551,24 @@ subroutine shoc_main ( &
     ! Check TKE to make sure values lie within acceptable
     !  bounds after vertical advection, etc.
     call check_tke(shcol,nlev,tke)
+
+    !---------------------------------------------
+    ! Send values to history output.
+    ! The outfld calls are placed here in order to capture field values
+    ! inside the time loop in this subroutine.
+    ! Here, we are relying on the assumption that the input variable shcol
+    ! equals ncol in tphysbc/tphysac, and that nlev/nlevi here equal
+    ! pver/pverp in tphysbc/tphysac.
+
+    if (t.le.turb_nadv_out_nstep) then
+
+       write(numstr,'(a1,i4.4)') '_',t
+
+       call outfld('SHOC_TKE'//trim(adjustl(numstr)),         tke,shcol,lchnk)
+       call outfld(  'THETAL'//trim(adjustl(numstr)),      thetal,shcol,lchnk)
+       call outfld( 'CLDFRAC'//trim(adjustl(numstr)),shoc_cldfrac,shcol,lchnk)
+    end if
+    !---------------------------------------------
 
   enddo ! end time loop
 

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -642,6 +642,9 @@ end function shoc_implements_cnst
    real(r8) :: se_dis(pcols), se_a(pcols), se_b(pcols), shoc_s(pcols,pver)
    real(r8) :: shoc_t(pcols,pver)
 
+   ! For SHOC substep output
+   integer :: turb_nadv_out_nstep     ! # of substeps to write out
+
    ! --------------- !
    ! Pointers        !
    ! --------------- !
@@ -682,6 +685,7 @@ end function shoc_implements_cnst
    !------------------------------------------------------------------!
    !------------------------------------------------------------------!
    !------------------------------------------------------------------!
+   call phys_getopts(turb_nadv_out_nstep_out = turb_nadv_out_nstep)
 
  !  Get indicees for cloud and ice mass and cloud and ice number
    ic_limit   = 1.e-12_r8
@@ -876,6 +880,7 @@ end function shoc_implements_cnst
    ! ------------------------------------------------- !
 
    call shoc_main( &
+        turb_nadv_out_nstep, lchnk, & ! Input
         ncol, pver, pverp, dtime, nadv, & ! Input
         host_dx_in(:ncol), host_dy_in(:ncol), thv(:ncol,:),& ! Input
         zt_g(:ncol,:), zi_g(:ncol,:), state%pmid(:ncol,:pver), state%pint(:ncol,:pverp), state1%pdel(:ncol,:pver),& ! Input

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -309,6 +309,14 @@ end function shoc_implements_cnst
 
     logical :: history_amwg
 
+    ! For writing out (to history files) the values from substeps used
+    ! by SHOC w.r.t. the mac-mic timesteps
+
+    integer :: turb_nadv_out_nstep     ! # of substeps to write out
+    integer :: iadv                    ! substep index
+    character(len=8) :: numstr         ! a string like "_0001" to append to variable names in history files
+    !-----------------------------------
+
     lq(1:pcnst) = .true.
     edsclr_dim = pcnst
 
@@ -324,6 +332,7 @@ end function shoc_implements_cnst
 
     call phys_getopts(prog_modal_aero_out=prog_modal_aero, &
                       history_amwg_out = history_amwg, &
+                      turb_nadv_out_nstep_out = turb_nadv_out_nstep, &
                       liqcf_fix_out   = liqcf_fix)
 
     ! Define physics buffers indexes
@@ -437,6 +446,24 @@ end function shoc_implements_cnst
     call add_default('PRECIPITATING_ICE_FRAC',1,' ')
     call add_default('LIQ_CLOUD_FRAC',1,' ')
     call add_default('TOT_CLOUD_FRAC',1,' ')
+
+    ! Add output variables from SHOC's internal substeps
+
+    if (turb_nadv_out_nstep.gt.0) then
+       do iadv = 1,turb_nadv_out_nstep
+
+          write(numstr,'(a1,i4.4)') '_',iadv
+
+          call addfld('SHOC_TKE'//trim(adjustl(numstr)), (/'lev'/), 'A', 'm2/s2', 'TKE')
+          call addfld(  'THETAL'//trim(adjustl(numstr)), (/'lev'/), 'A', 'K',     'liquid water potential temperature')
+          call addfld( 'CLDFRAC'//trim(adjustl(numstr)), (/'lev'/), 'A', '1',     'cloud fraction')
+
+          call add_default('SHOC_TKE'//trim(adjustl(numstr)), 1, ' ')
+          call add_default(  'THETAL'//trim(adjustl(numstr)), 1, ' ')
+          call add_default( 'CLDFRAC'//trim(adjustl(numstr)), 1, ' ')
+
+       end do
+    end if
 
     ! ---------------------------------------------------------------!
     ! Initialize SHOC                                                !
@@ -702,6 +729,7 @@ end function shoc_implements_cnst
    call pbuf_get_field(pbuf, icwmrdp_idx, dp_icwmr)
    call pbuf_get_field(pbuf, cmfmc_sh_idx, cmfmc_sh)
 
+   !--------------------
    !  Determine SHOC time step.
 
    dtime = shoc_timestep
@@ -731,6 +759,8 @@ end function shoc_implements_cnst
    !  determine number of timesteps SHOC core should be advanced,
    !  host time step divided by SHOC time step
    nadv = max(hdtime/dtime,1._r8)
+
+   !----------------------------
 
    ! Set grid space, in meters. If SCM, set to a grid size representative
    !  of a typical GCM.  Otherwise, compute locally.


### PR DESCRIPTION
This PR, currently marked as a draft, adds history output from CLUBB's and SHOC's `t=1,nadv` subcycles. Values from different subcycles corresponds to different NetCDF variables in the output file, e.g., `THETAL_0001`, `THETAL_0002`, etc.

Only 3 variables have been added for each parameterization as initial examples.

Note that for CLUBB, because the grid column loop is located outside the time loop, the code changes in this PR are not expected to work properly for multi-column/global simulations. If a user turns on the subcycle output when `single_column = .f.`, the simulation will abort.

-----
This implementation might not be the one that we will agree to adopt. Let's use this draft PR for further discussions.