### PR TITLE
Add namelist variable l_turb_standalone in EAM

### DIFF
--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -3106,6 +3106,13 @@ other values: EAM default (RRTMG)
 Default: 2
 </entry>
 
+<entry id="l_turb_standalone" type="logical" category="physc_test"
+       group="phys_ctl_nl" valid_values="" >
+Use EAM's code infrastructure but test the turbulence parameterization
+in a single-column standalone mode.
+Default: FALSE 
+</entry>
+
 <entry id="cflx_cpl_opt" type="integer" category="process_coupling"
        group="phys_ctl_nl" valid_values="" >
 Numerical scheme for coupling surface tracer fluxes with the rest of model.

--- a/components/eam/src/control/runtime_opts.F90
+++ b/components/eam/src/control/runtime_opts.F90
@@ -497,7 +497,7 @@ contains
    call history_readnl(nlfilename, dtime)
    call physconst_readnl(nlfilename)
    call chem_surfvals_readnl(nlfilename)
-   call phys_ctl_readnl(nlfilename)
+   call phys_ctl_readnl(nlfilename,single_column)
    call wv_sat_readnl(nlfilename)
    call ref_pres_readnl(nlfilename)
    call cam3_aero_data_readnl(nlfilename)

--- a/components/eam/src/physics/cam/clubb_intr.F90
+++ b/components/eam/src/physics/cam/clubb_intr.F90
@@ -702,17 +702,6 @@ end subroutine clubb_init_cnst
                       history_clubb_out=history_clubb,&
                       liqcf_fix_out   = liqcf_fix)
 
-    ! In case l_turb_standalone = .t., check if simulation is in single-column mode.
-    ! Abort if not.
-
-    if (l_turb_standalone) then
-       if (single_column) then
-          if (masterproc) write(iulog,*)'clubb_ini_cam: User has set l_turb_standalone = .t. and single_column = .t.'
-       else
-          call endrun('clubb_ini_cam: User has set l_turb_standalone = .t. but single_column = .f. Abort.')
-       end if
-    end if
-
     !  Select variables to apply tendencies back to CAM
 
     ! Initialize all consituents to true to start

--- a/components/eam/src/physics/cam/clubb_intr.F90
+++ b/components/eam/src/physics/cam/clubb_intr.F90
@@ -39,6 +39,9 @@ module clubb_intr
 
   use zm_conv,      only: zm_microp
 
+  use iop_data_mod,   only: single_column
+  use cam_abortutils, only: endrun
+
   implicit none
 
   private
@@ -129,6 +132,8 @@ module clubb_intr
     l_implemented    = .true.,        &  ! Implemented in a host model (always true)
     l_host_applies_sfc_fluxes = .false.  ! Whether the host model applies the surface fluxes
 
+  logical            :: l_turb_standalone  ! .t. = use EAM's code infrastructure but test CLUBB in
+                                           ! a single-column standalone mode
   logical            :: do_tms
   logical            :: linearize_pbl_winds
   logical            :: lq(pcnst)
@@ -692,9 +697,21 @@ end subroutine clubb_init_cnst
     ! ----------------------------------------------------------------- !
 
     call phys_getopts(prog_modal_aero_out=prog_modal_aero, &
+                      l_turb_standalone_out=l_turb_standalone, &
                       history_amwg_out=history_amwg, &
                       history_clubb_out=history_clubb,&
                       liqcf_fix_out   = liqcf_fix)
+
+    ! In case l_turb_standalone = .t., check if simulation is in single-column mode.
+    ! Abort if not.
+
+    if (l_turb_standalone) then
+       if (single_column) then
+          if (masterproc) write(iulog,*)'clubb_ini_cam: User has set l_turb_standalone = .t. and single_column = .t.'
+       else
+          call endrun('clubb_ini_cam: User has set l_turb_standalone = .t. but single_column = .f. Abort.')
+       end if
+    end if
 
     !  Select variables to apply tendencies back to CAM
 
@@ -2280,6 +2297,16 @@ end subroutine clubb_init_cnst
          pdf_params_zm%mixt_frac = pdf_zm_mixt_frac_inout
       end if
 
+      ! ------------------------------------------------------------- !
+      ! (Placeholder for now:) Initialization for "standalone" test
+      ! ------------------------------------------------------------- !
+      if (single_column.and.l_turb_standalone) then
+         call endrun('clubb_tend_cam: standalone test not yet fully implemented.')
+      end if
+
+      ! ------------------------------------------------------------- !
+      ! Time integration for CLUBB only
+      ! ------------------------------------------------------------- !
       call t_startf('adv_clubb_core_ts_loop')
       do t=1,nadv    ! do needed number of "sub" timesteps for each CAM step
 

--- a/components/eam/src/physics/cam/phys_control.F90
+++ b/components/eam/src/physics/cam/phys_control.F90
@@ -202,6 +202,9 @@ integer :: i_rad_scheme    = 2  ! or any value other than 0 or 1: the default ra
                                 ! 0: no radiation
                                 ! 1: LWP-based simplification from DYCOMS-II RF01 (Stevens et al., 2005)
 
+logical :: l_turb_standalone = .false. ! Use EAM's code infrastructure but test the turbulence parameterization
+                                       ! in a single-column standalone mode.
+
 logical :: modal_strat_sulfate_aod_treatment = .false.
 ! Numerical schemes for process coupling
 
@@ -258,6 +261,7 @@ subroutine phys_ctl_readnl(nlfile)
       cflx_cpl_opt, &
       l_tracer_aero, l_vdiff, l_rayleigh, l_gw_drag, l_ac_energy_chk, &
       l_bc_energy_fix, l_dry_adj, l_st_mac, l_st_mic, i_rad_scheme, prc_coef1,prc_exp,prc_exp1,cld_sed,mg_prc_coeff_fix, &
+      l_turb_standalone, &
       rrtmg_temp_fix, ideal_phys_option, &
       modal_strat_sulfate_aod_treatment
    !-----------------------------------------------------------------------------
@@ -395,6 +399,7 @@ subroutine phys_ctl_readnl(nlfile)
    call mpibcast(l_st_mac,                        1 , mpilog,  0, mpicom)
    call mpibcast(l_st_mic,                        1 , mpilog,  0, mpicom)
    call mpibcast(i_rad_scheme,                    1 , mpiint,  0, mpicom)
+   call mpibcast(l_turb_standalone,               1 , mpilog,  0, mpicom)
    call mpibcast(cld_macmic_num_steps,            1 , mpiint,  0, mpicom)
    call mpibcast(prc_coef1,                       1 , mpir8,   0, mpicom)
    call mpibcast(prc_exp,                         1 , mpir8,   0, mpicom)
@@ -613,6 +618,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
                        ,cflx_cpl_opt_out &
                        ,l_tracer_aero_out, l_vdiff_out, l_rayleigh_out, l_gw_drag_out, l_ac_energy_chk_out  &
                        ,l_bc_energy_fix_out, l_dry_adj_out, l_st_mac_out, l_st_mic_out, i_rad_scheme_out  &
+                       ,l_turb_standalone_out &
                        ,prc_coef1_out,prc_exp_out,prc_exp1_out, cld_sed_out,mg_prc_coeff_fix_out,rrtmg_temp_fix_out &
                        ,modal_strat_sulfate_aod_treatment_out)
 
@@ -719,6 +725,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
    logical,           intent(out), optional :: l_st_mac_out
    logical,           intent(out), optional :: l_st_mic_out
    integer,           intent(out), optional :: i_rad_scheme_out
+   logical,           intent(out), optional :: l_turb_standalone_out
    logical,           intent(out), optional :: mg_prc_coeff_fix_out
    logical,           intent(out), optional :: rrtmg_temp_fix_out
    logical,           intent(out), optional :: modal_strat_sulfate_aod_treatment_out
@@ -825,6 +832,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
    if ( present(l_st_mac_out            ) ) l_st_mac_out          = l_st_mac
    if ( present(l_st_mic_out            ) ) l_st_mic_out          = l_st_mic
    if ( present(i_rad_scheme_out        ) ) i_rad_scheme_out      = i_rad_scheme
+   if ( present(l_turb_standalone_out   ) ) l_turb_standalone_out = l_turb_standalone
    if ( present(cld_macmic_num_steps_out) ) cld_macmic_num_steps_out = cld_macmic_num_steps
    if ( present(prc_coef1_out           ) ) prc_coef1_out            = prc_coef1
    if ( present(prc_exp_out             ) ) prc_exp_out              = prc_exp

--- a/components/eam/src/physics/cam/phys_control.F90
+++ b/components/eam/src/physics/cam/phys_control.F90
@@ -216,7 +216,7 @@ integer :: cflx_cpl_opt = 1  ! When to apply surface tracer fluxes (not includin
 contains
 !======================================================================= 
 
-subroutine phys_ctl_readnl(nlfile)
+subroutine phys_ctl_readnl(nlfile,single_column_in)
 
    use namelist_utils,  only: find_group_name
    use units,           only: getunit, freeunit
@@ -225,6 +225,7 @@ subroutine phys_ctl_readnl(nlfile)
    use physconst,       only: pi
 
    character(len=*), intent(in) :: nlfile  ! filepath for file containing namelist input
+   logical, intent(in) :: single_column_in ! is the simulation in a single-column mode 
 
    ! Local variables
    integer :: unitn, ierr
@@ -285,6 +286,7 @@ subroutine phys_ctl_readnl(nlfile)
       if (get_presc_aero_data) then
         history_aerosol = .true.
       endif
+
 
    end if
    if (history_chemdyg_summary) then
@@ -548,6 +550,15 @@ subroutine phys_ctl_readnl(nlfile)
      endif
    endif
     
+   ! Allow l_turb_standalone = .t. only in single-column mode.
+   if (l_turb_standalone) then
+      if (single_column_in) then
+         if (masterproc) write(iulog,*) subname//': User has set l_turb_standalone = .t. and single_column = .t.'
+      else      
+         call endrun(subname//': User has set l_turb_standalone = .t. but single_column = .f. Abort.')
+      end if        
+   end if
+
 end subroutine phys_ctl_readnl
 
 !===============================================================================

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -331,17 +331,6 @@ end function shoc_implements_cnst
                       history_amwg_out = history_amwg, &
                       liqcf_fix_out   = liqcf_fix)
 
-    ! In case l_turb_standalone = .t., check if simulation is in single-column mode.
-    ! Abort if not.  
-
-    if (l_turb_standalone) then
-       if (single_column) then
-          if (masterproc) write(iulog,*)'shoc_init_e3sm: User has set l_turb_standalone = .t. and single_column = .t.'
-       else          
-          call endrun('shoc_init_e3sm: User has set l_turb_standalone = .t. but single_column = .f. Abort.')
-       end if        
-    end if           
-
     ! Define physics buffers indexes
     cld_idx     = pbuf_get_index('CLD')         ! Cloud fraction
     tot_cloud_frac_idx     = pbuf_get_index('TOT_CLOUD_FRAC')         ! Cloud fraction

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -27,6 +27,7 @@ module shoc_intr
   use shoc,          only: linear_interp, largeneg
   use spmd_utils,    only: masterproc
   use cam_abortutils, only: endrun
+  use iop_data_mod,   only: single_column
 
   implicit none
 
@@ -85,6 +86,9 @@ module shoc_intr
   logical            :: history_budget
   integer            :: history_budget_histfile_num
   logical            :: micro_do_icesupersat
+
+  logical            :: l_turb_standalone  ! .t. = use EAM's code infrastructure but test SHOC in
+                                           ! a single-column standalone mode
 
   character(len=16)  :: eddy_scheme      ! Default set in phys_control.F90
   character(len=16)  :: deep_scheme      ! Default set in phys_control.F90
@@ -323,8 +327,20 @@ end function shoc_implements_cnst
     ! ----------------------------------------------------------------- !
 
     call phys_getopts(prog_modal_aero_out=prog_modal_aero, &
+                      l_turb_standalone_out=l_turb_standalone, &
                       history_amwg_out = history_amwg, &
                       liqcf_fix_out   = liqcf_fix)
+
+    ! In case l_turb_standalone = .t., check if simulation is in single-column mode.
+    ! Abort if not.  
+
+    if (l_turb_standalone) then
+       if (single_column) then
+          if (masterproc) write(iulog,*)'shoc_init_e3sm: User has set l_turb_standalone = .t. and single_column = .t.'
+       else          
+          call endrun('shoc_init_e3sm: User has set l_turb_standalone = .t. but single_column = .f. Abort.')
+       end if        
+    end if           
 
     ! Define physics buffers indexes
     cld_idx     = pbuf_get_index('CLD')         ! Cloud fraction
@@ -841,9 +857,17 @@ end function shoc_implements_cnst
      end if
    enddo
 
+   ! ------------------------------------------------------------- !
+   ! (Placeholder for now:) Initialization for "standalone" test
+   ! ------------------------------------------------------------- !
+   if (single_column.and.l_turb_standalone) then
+      call endrun('shoc_tend_e3sm: standalone test not yet fully implemented.')
+   end if
+
    ! ------------------------------------------------- !
    ! Actually call SHOC                                !
    ! ------------------------------------------------- !
+   ! Note that this call includes nadv time steps of integration for SHOC
 
    call shoc_main( &
         ncol, pver, pverp, dtime, nadv, & ! Input


### PR DESCRIPTION
- Default value is .false.
- `l_turb_standalone = .true.` is allowed only when `single_column = .true.`
- Placeholders are added to `clubb_intr.F90` and `shoc_intr.F90` for upcoming code addition (e.g., initialization of the "in-and-out" simulations).

With this commit, if the user configures a SCM simulation and sets `l_turb_standalone = .true.`, the executable will run and write into atm.log a line like

  `shoc_init_e3sm: User has set l_turb_standalone = .t. and single_column = .t.`

or

  `clubb_ini_cam: User has set l_turb_standalone = .t. and single_column = .t.`

After that, during the first time step, the job will abort and write into atm.log a line like

  `ERROR: shoc_tend_e3sm: standalone test not yet fully implemented.`

or

  `ERROR: clubb_tend_cam: standalone test not yet fully implemented.`