### PR TITLE
Correct initialization of model top and bottom

### DIFF
--- a/components/eam/src/control/getinterpnetcdfdata.F90
+++ b/components/eam/src/control/getinterpnetcdfdata.F90
@@ -344,11 +344,23 @@ subroutine interplevs( inputdata,   dplevs,   nlev, &
 !     fill in the missing end values 
 !           (usually  done if this is global model dataset)
 !
+! Note from 2025-12-03 (hui.wan@pnnl.gov):
+! The original start and end values of the loop variables lead to the following results:
+!  - If the model domain exceeds the data domain on one side or both (top and/or bottom),
+!    not only the extra levels, but also the level(s) that is (are) just inside the data domain,
+!    are filled with values at the corresponding end(s) of the data domain. This is fine.
+!  - If the model domain is smaller than the data domain on one side or both sides,
+!    then the first and/or last level of data will always be copied to the first and/or last level
+!    of the model, which can cause big jumps at model top and/or bottom.
+! The revised loops only copy data to model levels that are outside the data domain.
+
    if ( fill_ends ) then 
-      do i=1, mstart_lev
+     !do i=1, mstart_lev
+      do i=1, mstart_lev-1
          outdata(i) = inputdata(1)
       end do
-      do i= mend_lev, plev
+     !do i= mend_lev, plev
+      do i= mend_lev+1, plev
          outdata(i) = inputdata(nlev)
       end do
    end if


### PR DESCRIPTION
In E3SM SCM simulations, contents of IOP files are read in and interpolated to model layers, in subroutine [`readiopdata`](https://github.com/PAESCAL-SciDAC5/E3SM-fork/blob/f82d08e57d8428fc1d24d348d28a91d7a3bbef00/components/eam/src/control/iop_data_mod.F90#L630), by calling the subroutine [`getinterpncdata`](https://github.com/PAESCAL-SciDAC5/E3SM-fork/blob/f82d08e57d8428fc1d24d348d28a91d7a3bbef00/components/eam/src/control/getinterpnetcdfdata.F90#L22) which calls [`interplevs`](https://github.com/PAESCAL-SciDAC5/E3SM-fork/blob/f82d08e57d8428fc1d24d348d28a91d7a3bbef00/components/eam/src/control/getinterpnetcdfdata.F90#L247) for interpolation. The code takes into the fact that there might be model levels outside (i.e., above the top or below the bottom of) the domain of the IOP data. For those "extra" levels, different model variables are treated differently.
- For temperature, humidity, u-wind, v-wind, `getinterpncdata` is called with `fill_ends = .true.`, so that IOP data values at the ends (top and bottom) of the IOP data domain are copied to (1) the "extra" model levels and (2) the first model level that is below the top of the IOP domain and the first model level that is above the bottom of the IOP domain.
- For other variables, `getinterpncdata` is called with `fill_ends = .false.`, so that no explicit initialization is done for the "extra" model levels.

In our SCM simulations with low-top grids, the model top lies within the IOP data domain, hence no filling is needed. But because of (2) mentioned in the first bullet above, the top level of the model grid is always filled with T, q, u, v values from the top level of the IOP domain, resulting in very strong gradients (at least in T and q) across the first two levels at model top. (Similarly, the bottom level of the model grid is always filled with T, q, u, v values from the bottom level of the IOP domain.)

**This PR modifies the `fill_ends = .true.` option so that the filling is applied only to the "extra" model levels that are outside the IOP domain.**

----
Figures below illustrates the impact on DYCOMS-II RF01 simulations. Note that 

- for simulations using CLUBB, the impact is most clearly seen in cloud fraction;
- for simulations using SHOC, the impact is most clearly seen in temperature.

<img width="1437" height="629" alt="CLOUD_before_after_correction_CLUBB" src="https://github.com/user-attachments/assets/539817a3-edcc-4fb0-961e-c53f907d0c94" />

<img width="1437" height="629" alt="T_before_after_correction_CLUBB" src="https://github.com/user-attachments/assets/8832a7f3-f77f-48bd-8482-286a90f441e0" />

<img width="1462" height="608" alt="T_before_after_correction_SHOC" src="https://github.com/user-attachments/assets/042b3abc-bd17-44e9-99ba-0c8c3089a020" />
