### PR TITLE
Add namelist variable host_dx_dy

### DIFF
--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -3816,6 +3816,8 @@ if ($shoc_sgs  =~ /$TRUE/io) {
    add_default($nl, 'shoc_Ckm');
    add_default($nl, 'shoc_Ckh_s');
    add_default($nl, 'shoc_Ckm_s');
+   add_default($nl, 'shoc_output_prefix');
+   add_default($nl, 'l_shoc_outer_loop');
 }
 
 

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -833,6 +833,8 @@
 <shoc_Ckm                    > 0.1D0 </shoc_Ckm>
 <shoc_Ckh_s                  > 0.1D0 </shoc_Ckh_s>
 <shoc_Ckm_s                  > 0.1D0 </shoc_Ckm_s>
+<shoc_output_prefix          > '' </shoc_output_prefix>
+<l_shoc_outer_loop           > .true. </l_shoc_outer_loop>
 
 <!-- CLUBB options -->
 <clubb_rainevap_turb                              > .false. </clubb_rainevap_turb>

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -3455,6 +3455,22 @@ Coefficient for eddy diffusivity for momentum for stable boundary layers.
 Default: set by build-namelist
 </entry>
 
+<entry id="shoc_output_prefix" type="char*256" category="pblrad"
+       group="shocpbl_diff_nl" valid_values="" >
+Prefix for SHOC text output filenames used in in-and-out experiments.
+Output files are named {prefix}_nadv{N}_x_shocm{M}_nstep{NSTEPS}_macmicsub{MACMICSUB}.txt.
+When empty (default), a built-in prefix 'shoc_output' is used.
+Default: ''
+</entry>
+
+<entry id="l_shoc_outer_loop" type="logical" category="pblrad"
+       group="shocpbl_diff_nl" valid_values="" >
+Controls in-and-out experiment mode for SHOC.
+  .false. = experiment 1: single shoc_main call with large nadv (output from shoc.F90)
+  .true.  = experiment 2: many shoc_main calls with nadv=1 (output from shoc_intr.F90)
+Default: .true.
+</entry>
+
 <entry id="clubb_cloudtop_cooling" type="logical"  category="pblrad"
        group="clubbpbl_diff_nl" valid_values="" >
 Apply cloud top radiative cooling parameterization

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -3351,6 +3351,16 @@ liq cloud fraction bug in macro and micro physics
 Default: .false.
 </entry>
 
+<!-- host model dx and dy assumed for turbulence parameterization -->
+<entry id="host_dx_dy" type="real" category="physc_test"
+       group="phys_ctl_nl" valid_values="" >
+Host model delta-x and delta-y (same value) assumed for
+- CLUBB;
+- SHOC when called in SCM mode.
+Default: 100000.
+Unit: m
+</entry>
+
 <!-- SHOC timestep -->
 <entry id="shoc_timestep" type="real" category="pblrad"
        group="shocpbl_diff_nl" valid_values="" >

--- a/components/eam/src/physics/cam/clubb_intr.F90
+++ b/components/eam/src/physics/cam/clubb_intr.F90
@@ -88,9 +88,10 @@ module clubb_intr
       ts_nudge = 86400._core_rknd, &    ! Time scale for u/v nudging (not used)     [s]
       p0_clubb = 100000._core_rknd
 
-  real(core_rknd), parameter :: &
-      host_dx = 100000._core_rknd, &    ! Host model deltax [m]
-      host_dy = 100000._core_rknd       ! Host model deltay [m]
+  real(core_rknd) :: host_dx  ! Host model deltax [m]
+  real(core_rknd) :: host_dy  ! Host model deltay [m]
+
+  real(r8) :: host_dx_dy_nml  ! Host model delta-x, delta-y set in namelist [m]
 
   integer, parameter :: &
     sclr_dim = 0                        ! Higher-order scalars, set to zero
@@ -712,7 +713,15 @@ end subroutine clubb_init_cnst
                       history_amwg_out=history_amwg, &
                       history_clubb_out=history_clubb,&
                       turb_nadv_out_nstep_out = turb_nadv_out_nstep, &
+                      host_dx_dy_out  = host_dx_dy_nml, &
                       liqcf_fix_out   = liqcf_fix)
+
+    write(iulog,*) 'clubb_init_e3sm: l_turb_standalone   = ',l_turb_standalone
+    write(iulog,*) 'clubb_init_e3sm: host_dx_dy_nml      = ',host_dx_dy_nml
+    write(iulog,*) 'clubb_init_e3sm: turb_nadv_out_nstep = ',turb_nadv_out_nstep
+
+    host_dx = real(host_dx_dy_nml, kind=core_rknd)
+    host_dy = real(host_dx_dy_nml, kind=core_rknd)
 
     !  Select variables to apply tendencies back to CAM
 

--- a/components/eam/src/physics/cam/phys_control.F90
+++ b/components/eam/src/physics/cam/phys_control.F90
@@ -210,6 +210,9 @@ integer :: i_rad_scheme    = 2  ! or any value other than 0 or 1: the default ra
 logical :: l_turb_standalone = .false. ! Use EAM's code infrastructure but test the turbulence parameterization
                                        ! in a single-column standalone mode.
 
+real(r8) :: host_dx_dy = 100000._r8    ! Host model delta-x and delta-y (same value) assumed (1) for CLUBB,
+                                       ! or (2) for SHOC when it is called in SCM mode. Unit: m
+
 logical :: modal_strat_sulfate_aod_treatment = .false.
 ! Numerical schemes for process coupling
 
@@ -267,7 +270,7 @@ subroutine phys_ctl_readnl(nlfile,single_column_in)
       cflx_cpl_opt, &
       l_tracer_aero, l_vdiff, l_rayleigh, l_gw_drag, l_ac_energy_chk, &
       l_bc_energy_fix, l_dry_adj, l_st_mac, l_st_mic, i_rad_scheme, prc_coef1,prc_exp,prc_exp1,cld_sed,mg_prc_coeff_fix, &
-      l_turb_standalone, &
+      l_turb_standalone, host_dx_dy, &
       rrtmg_temp_fix, ideal_phys_option, &
       modal_strat_sulfate_aod_treatment
    !-----------------------------------------------------------------------------
@@ -408,6 +411,7 @@ subroutine phys_ctl_readnl(nlfile,single_column_in)
    call mpibcast(l_st_mic,                        1 , mpilog,  0, mpicom)
    call mpibcast(i_rad_scheme,                    1 , mpiint,  0, mpicom)
    call mpibcast(l_turb_standalone,               1 , mpilog,  0, mpicom)
+   call mpibcast(host_dx_dy,                      1 , mpir8,   0, mpicom)
    call mpibcast(cld_macmic_num_steps,            1 , mpiint,  0, mpicom)
    call mpibcast(prc_coef1,                       1 , mpir8,   0, mpicom)
    call mpibcast(prc_exp,                         1 , mpir8,   0, mpicom)
@@ -636,7 +640,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
                        ,cflx_cpl_opt_out &
                        ,l_tracer_aero_out, l_vdiff_out, l_rayleigh_out, l_gw_drag_out, l_ac_energy_chk_out  &
                        ,l_bc_energy_fix_out, l_dry_adj_out, l_st_mac_out, l_st_mic_out, i_rad_scheme_out  &
-                       ,l_turb_standalone_out &
+                       ,l_turb_standalone_out, host_dx_dy_out &
                        ,prc_coef1_out,prc_exp_out,prc_exp1_out, cld_sed_out,mg_prc_coeff_fix_out,rrtmg_temp_fix_out &
                        ,modal_strat_sulfate_aod_treatment_out)
 
@@ -745,6 +749,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
    logical,           intent(out), optional :: l_st_mic_out
    integer,           intent(out), optional :: i_rad_scheme_out
    logical,           intent(out), optional :: l_turb_standalone_out
+   real(r8),          intent(out), optional :: host_dx_dy_out
    logical,           intent(out), optional :: mg_prc_coeff_fix_out
    logical,           intent(out), optional :: rrtmg_temp_fix_out
    logical,           intent(out), optional :: modal_strat_sulfate_aod_treatment_out
@@ -853,6 +858,7 @@ subroutine phys_getopts(deep_scheme_out, shallow_scheme_out, eddy_scheme_out, &
    if ( present(l_st_mic_out            ) ) l_st_mic_out          = l_st_mic
    if ( present(i_rad_scheme_out        ) ) i_rad_scheme_out      = i_rad_scheme
    if ( present(l_turb_standalone_out   ) ) l_turb_standalone_out = l_turb_standalone
+   if ( present(host_dx_dy_out          ) ) host_dx_dy_out        = host_dx_dy
    if ( present(cld_macmic_num_steps_out) ) cld_macmic_num_steps_out = cld_macmic_num_steps
    if ( present(prc_coef1_out           ) ) prc_coef1_out            = prc_coef1
    if ( present(prc_exp_out             ) ) prc_exp_out              = prc_exp

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -14,6 +14,7 @@ module shoc
 
   use physics_utils, only: rtype, rtype8, itype, btype
   use scream_abortutils, only: endscreamrun
+  use spmd_utils, only: masterproc
 
 ! Bit-for-bit math functions.
 #ifdef SCREAM_CONFIG_IS_CMAKE
@@ -31,6 +32,8 @@ logical :: use_cxx = .true.
 real(rtype), parameter, public :: largeneg = -99999999.99_rtype
 real(rtype), parameter, public :: pi = 3.14159265358979323_rtype
 
+!character(len=*), parameter, public :: fmt = '(i8,i4,20ES22.13)'
+character(len=*), parameter, public :: fmt = '(I5,1X,I4,5(1X,F17.14),1X,F16.12,1X,F17.10)'
 !=========================================================
 ! Physical constants used in SHOC
 !=========================================================
@@ -221,6 +224,7 @@ end subroutine shoc_init
 ! Host models should call the following routine to call SHOC
 
 subroutine shoc_main ( &
+     l_txt_write, txtout_unit, &          ! Input
      turb_nadv_out_nstep, lchnk, &        ! Input
      shcol, nlev, nlevi, dtime, nadv, &   ! Input
      host_dx, host_dy,thv, &              ! Input
@@ -253,6 +257,8 @@ subroutine shoc_main ( &
 
 ! INPUT VARIABLES
 
+  logical, intent(in) :: l_txt_write         ! Whether results will be written out to a txt file within the nadv loop
+  integer, intent(in) :: txtout_unit         ! File handle for txt output
   integer, intent(in) :: turb_nadv_out_nstep ! # of time steps (in this subr.) to write out fields for
   integer, intent(in) :: lchnk               ! chunk ID related to the host model's domain decomposition
 
@@ -407,6 +413,8 @@ subroutine shoc_main ( &
               wv_b(shcol),wl_b(shcol),&
               se_a(shcol),ke_a(shcol),&
               wv_a(shcol),wl_a(shcol)
+
+  integer :: kk
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
   integer :: clock_count1, clock_count_rate, clock_count_max, clock_count2, clock_count_diff
@@ -567,6 +575,21 @@ subroutine shoc_main ( &
        call outfld('SHOC_TKE'//trim(adjustl(numstr)),         tke,shcol,lchnk)
        call outfld(  'THETAL'//trim(adjustl(numstr)),      thetal,shcol,lchnk)
        call outfld( 'CLDFRAC'//trim(adjustl(numstr)),shoc_cldfrac,shcol,lchnk)
+    end if
+
+    !---------------------------------------------
+    ! Write out fields to SHOC text output file
+
+    if (l_txt_write.and.masterproc) then
+      do kk=nlev,1,-1
+         write(txtout_unit,fmt) t*nint(dtime),                                           &! time elapsed inside this subroutine 
+                                kk-1,                                                    &! vertical layer index (0 = TOM, nlev - 1 = sfc)
+                                u_wind(1,kk), v_wind(1,kk), tke(1,kk),                   &! u, v, and tke
+                                    qw(1,kk)-shoc_ql(1,kk),                              &! qv
+                               shoc_ql(1,kk),                                            &! qc
+                                thetal(1,kk)/inv_exner(1,kk) + lcond/cp * shoc_ql(1,kk), &! temperature
+                                  pres(1,kk)                                              ! pressure
+      end do
     end if
     !---------------------------------------------
 

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -28,6 +28,8 @@ module shoc_intr
   use spmd_utils,    only: masterproc
   use cam_abortutils, only: endrun
   use iop_data_mod,   only: single_column
+  use units, only:  getunit, freeunit
+  use time_manager,  only: get_nstep
 
   implicit none
 
@@ -87,8 +89,16 @@ module shoc_intr
   integer            :: history_budget_histfile_num
   logical            :: micro_do_icesupersat
 
-  logical            :: l_turb_standalone  ! .t. = use EAM's code infrastructure but test SHOC in
-                                           ! a single-column standalone mode
+  logical :: l_turb_standalone = .false.  ! .true. = use EAM's code infrastructure but test SHOC in
+                                          !          a single-column standalone mode
+
+  logical :: l_shoc_outer_loop = .false.  ! .false. = Use a single shoc_main call with nadv calculated from
+                                          !           the host model's and SHOC's step sizes. When l_turb_standalone = .t.,
+                                          !           text output is written from the subroutine shoc_main inside shoc.F90
+                                          ! .true.  = The number of shoc_main calls is calculated from the
+                                          !           host model's and SHOC's step sizes; each call uses nadv=1.
+                                          !           When l_turb_standalone = .t.,, text output is written from
+                                          !           subroutine shoc_tend_e3sm in this module.
 
   character(len=16)  :: eddy_scheme      ! Default set in phys_control.F90
   character(len=16)  :: deep_scheme      ! Default set in phys_control.F90
@@ -127,6 +137,9 @@ module shoc_intr
 
   logical :: liqcf_fix = .FALSE.  ! HW for liquid cloud fraction fix
   logical :: relvar_fix = .FALSE. !PMA for relvar fix
+
+  ! Prefix for SHOC text output filenames (set via namelist shoc_output_prefix)
+  character(len=256) :: shoc_output_prefix = ''
 
   contains
 
@@ -236,7 +249,8 @@ end function shoc_implements_cnst
                                shoc_w2tune, shoc_length_fac, shoc_c_diag_3rd_mom, &
                                shoc_lambda_low, shoc_lambda_high, shoc_lambda_slope, &
                                shoc_lambda_thresh, shoc_Ckh, shoc_Ckm, shoc_Ckh_s, &
-                               shoc_Ckm_s
+                               shoc_Ckm_s, shoc_output_prefix, &
+                               l_shoc_outer_loop
 
     !  Read namelist to determine if SHOC history should be called
     if (masterproc) then
@@ -272,6 +286,8 @@ end function shoc_implements_cnst
       call mpibcast(shoc_Ckm,                1,   mpir8,   0, mpicom)
       call mpibcast(shoc_Ckh_s,              1,   mpir8,   0, mpicom)
       call mpibcast(shoc_Ckm_s,              1,   mpir8,   0, mpicom)
+      call mpibcast(shoc_output_prefix, len(shoc_output_prefix), mpichar, 0, mpicom)
+      call mpibcast(l_shoc_outer_loop,        1,   mpilog,  0, mpicom)
 #endif
 
   end subroutine shoc_readnl
@@ -537,7 +553,7 @@ end function shoc_implements_cnst
     use micro_mg_cam,   only: micro_mg_version
     use cldfrc2m,                  only: aist_vector
     use trb_mtn_stress,            only: compute_tms
-    use shoc,           only: shoc_main
+    use shoc,           only: shoc_main, fmt
     use cam_history,    only: outfld
     use iop_data_mod,   only: single_column, dp_crm
 
@@ -584,7 +600,19 @@ end function shoc_implements_cnst
    type(physics_state) :: state1                ! Local copy of state variable
    type(physics_ptend) :: ptend_loc             ! Local tendency from processes, added up to return as ptend_all
 
-   integer :: i, j, k, t, ixind, nadv
+   integer :: i, j, k, t, ixind
+   integer :: shoc_num_steps                    ! Number of SHOC substeps within a host timestep of length hdtime.
+                                                ! This number should equal (n_shoc_main_calls * nadv).
+                                                ! In the current implementation, one of the two variables,
+                                                ! n_shoc_main_calls and nadv, is set to shoc_num_steps, leaving
+                                                ! the other to be 1.
+
+   integer :: n_shoc_main_calls                 ! Number of times shoc_main is called within this interface
+   integer :: nadv                              ! Number of timesteps inside each call of shoc_main
+
+   logical :: l_inner_write
+   character(len=256)  :: txt_output_prefix = ''
+
    integer :: ixcldice, ixcldliq, ixnumliq, ixnumice
    integer :: itim_old
    integer :: ncol, lchnk                       ! # of columns, and chunk identifier
@@ -657,6 +685,12 @@ end function shoc_implements_cnst
 
    ! For SHOC substep output
    integer :: turb_nadv_out_nstep     ! # of substeps to write out
+
+   integer :: txtout_unit
+   character(len=512) :: outfname
+   integer :: i_shoc_main
+
+   integer :: kk
 
    ! --------------- !
    ! Pointers        !
@@ -775,7 +809,7 @@ end function shoc_implements_cnst
 
    !  determine number of timesteps SHOC core should be advanced,
    !  host time step divided by SHOC time step
-   nadv = max(hdtime/dtime,1._r8)
+   shoc_num_steps = max(nint(hdtime/dtime), 1)
 
    !----------------------------
 
@@ -888,37 +922,119 @@ end function shoc_implements_cnst
      end if
    enddo
 
-   ! ------------------------------------------------------------- !
-   ! (Placeholder for now:) Initialization for "standalone" test
-   ! ------------------------------------------------------------- !
-   if (single_column.and.l_turb_standalone) then
-      call endrun('shoc_tend_e3sm: standalone test not yet fully implemented.')
+   !-------------------------------------------
+   ! Substepping configuration (if applicable)
+   !-------------------------------------------
+   if (l_shoc_outer_loop) then
+      n_shoc_main_calls = shoc_num_steps
+      nadv = 1
+   else
+      n_shoc_main_calls = 1
+      nadv = shoc_num_steps
    end if
+
+   !----------------------------------------------------------------------------------
+   ! Initialization/preparation for "standalone"/"in-and-out" test (only in SCM mode)
+   !----------------------------------------------------------------------------------
+   if (l_turb_standalone) then
+
+      ! Overwrite values of shoc_main's input variables using values from txt files
+
+      call read_and_set_input_to_shoc_main( &
+             ncol, thv, zt_g, zi_g, state1%pmid, state1%pint, state1%pdel, &
+             wpthlp_sfc, wprtp_sfc, upwp_sfc, vpwp_sfc, inv_exner, tke_zt, &
+             thlm, rtm, um, vm, wm_zt, rcm, cloud_frac, tkh, tk )
+
+      wthv(:ncol,:) = 0.0_r8
+
+      if (masterproc) then
+
+         ! Determine name of txt output file
+
+         txt_output_prefix = 'shoc_output'
+         if (len_trim(shoc_output_prefix) > 0) txt_output_prefix = trim(shoc_output_prefix)
+         write(outfname, '(A,4(A,I0),A)') trim(txt_output_prefix), &
+                                          '_nadv', nadv, '_x_shocm',n_shoc_main_calls, &
+                                          '_nstep',get_nstep(), '_macmicsub',macmic_it,&
+                                          '.txt'
+
+         ! Open txt file and write a header
+
+         txtout_unit = getunit()
+         open(txtout_unit, file=trim(outfname), status='replace')
+         write(txtout_unit,*) 'time, k (0 = TOM, pver - 1 = sfc), u, v, tke, qv, qc, T, P'
+
+         ! Send info to iulog to double check
+
+         write(iulog,*) 'shoc_num_steps    = ', shoc_num_steps
+         write(iulog,*) 'n_shoc_main_calls = ', n_shoc_main_calls
+         write(iulog,*) 'nadv              = ', nadv
+
+      end if  ! masterproc
+
+   end if ! l_turb_standalone
+
+   ! Write statement inside shoc_main will only be executed when the simulation
+   ! is run in an SCM "turb standalone" model when the nadv loop inside shoc_main
+   ! is used to take multiple substeps.
+
+   l_inner_write = l_turb_standalone .and. (.not.l_shoc_outer_loop)
 
    ! ------------------------------------------------- !
    ! Actually call SHOC                                !
    ! ------------------------------------------------- !
-   ! Note that this call includes nadv time steps of integration for SHOC
+   ! Note that each call includes nadv time steps of integration for SHOC
 
-   call shoc_main( &
-        turb_nadv_out_nstep, lchnk, & ! Input
-        ncol, pver, pverp, dtime, nadv, & ! Input
-        host_dx_in(:ncol), host_dy_in(:ncol), thv(:ncol,:),& ! Input
-        zt_g(:ncol,:), zi_g(:ncol,:), state%pmid(:ncol,:pver), state%pint(:ncol,:pverp), state1%pdel(:ncol,:pver),& ! Input
-        wpthlp_sfc(:ncol), wprtp_sfc(:ncol), upwp_sfc(:ncol), vpwp_sfc(:ncol), & ! Input
-        wtracer_sfc(:ncol,:), edsclr_dim, wm_zt(:ncol,:), & ! Input
-        inv_exner(:ncol,:),state1%phis(:ncol), & ! Input
-        shoc_s(:ncol,:), tke_zt(:ncol,:), thlm(:ncol,:), rtm(:ncol,:), & ! Input/Ouput
-        um(:ncol,:), vm(:ncol,:), edsclr_in(:ncol,:,:), & ! Input/Output
-        wthv(:ncol,:),tkh(:ncol,:),tk(:ncol,:), & ! Input/Output
-        rcm(:ncol,:),cloud_frac(:ncol,:), & ! Input/Output
-        pblh(:ncol), & ! Output
-        shoc_mix_out(:ncol,:), isotropy_out(:ncol,:), & ! Output (diagnostic)
-        w_sec_out(:ncol,:), thl_sec_out(:ncol,:), qw_sec_out(:ncol,:), qwthl_sec_out(:ncol,:), & ! Output (diagnostic)
-        wthl_sec_out(:ncol,:), wqw_sec_out(:ncol,:), wtke_sec_out(:ncol,:), & ! Output (diagnostic)
-        uw_sec_out(:ncol,:), vw_sec_out(:ncol,:), w3_out(:ncol,:), & ! Output (diagnostic)
-        wqls_out(:ncol,:),brunt_out(:ncol,:),rcm2(:ncol,:)) ! Output (diagnostic)
+   !============================
+   do i_shoc_main = 1, n_shoc_main_calls
 
+      call shoc_main( &
+           l_inner_write, txtout_unit,     & ! Input
+           turb_nadv_out_nstep, lchnk,     & ! Input
+           ncol, pver, pverp, dtime, nadv, & ! Input
+           host_dx_in(:ncol), host_dy_in(:ncol), thv(:ncol,:),& ! Input
+          !The line commented out below was in the original E3SM code. Was the use of state instead of state1 for pmid and pint a typo?
+          !zt_g(:ncol,:), zi_g(:ncol,:), state%pmid(:ncol,:pver), state%pint(:ncol,:pverp), state1%pdel(:ncol,:pver),& ! Input
+           zt_g(:ncol,:), zi_g(:ncol,:),state1%pmid(:ncol,:pver),state1%pint(:ncol,:pverp), state1%pdel(:ncol,:pver),& ! Input
+           wpthlp_sfc(:ncol), wprtp_sfc(:ncol), upwp_sfc(:ncol), vpwp_sfc(:ncol), & ! Input
+           wtracer_sfc(:ncol,:), edsclr_dim, wm_zt(:ncol,:), & ! Input
+           inv_exner(:ncol,:),state1%phis(:ncol), & ! Input
+           shoc_s(:ncol,:), tke_zt(:ncol,:), thlm(:ncol,:), rtm(:ncol,:), & ! Input/Ouput
+           um(:ncol,:), vm(:ncol,:), edsclr_in(:ncol,:,:), & ! Input/Output
+           wthv(:ncol,:),tkh(:ncol,:),tk(:ncol,:), & ! Input/Output
+           rcm(:ncol,:),cloud_frac(:ncol,:), & ! Input/Output
+           pblh(:ncol), & ! Output
+           shoc_mix_out(:ncol,:), isotropy_out(:ncol,:), & ! Output (diagnostic)
+           w_sec_out(:ncol,:), thl_sec_out(:ncol,:), qw_sec_out(:ncol,:), qwthl_sec_out(:ncol,:), & ! Output (diagnostic)
+           wthl_sec_out(:ncol,:), wqw_sec_out(:ncol,:), wtke_sec_out(:ncol,:), & ! Output (diagnostic)
+           uw_sec_out(:ncol,:), vw_sec_out(:ncol,:), w3_out(:ncol,:), & ! Output (diagnostic)
+           wqls_out(:ncol,:),brunt_out(:ncol,:),rcm2(:ncol,:)) ! Output (diagnostic)
+
+      ! Write results to txt file after each shoc_main call if conditions are met.
+
+      if (l_turb_standalone .and. l_shoc_outer_loop .and. masterproc) then
+           do kk = pver, 1, -1
+              write(txtout_unit,fmt) i_shoc_main * nint(dtime), &!
+                                     kk - 1,                    &! 0 = TOM, pver - 1 = sfc
+                                     um(1,kk),                  &!
+                                     vm(1,kk),                  &!
+                                     tke_zt(1,kk),              &!
+                                     rtm(1,kk) - rcm(1,kk),     &! qv
+                                     rcm(1,kk),                 &! qc
+                                     thlm(1,kk) / inv_exner(1,kk) + latvap/cpair * rcm(1,kk), &! temperature
+                                     state1%pmid(1,kk)                                         ! pressure
+           end do
+      end if
+
+  end do  ! end i_shoc_main loop
+  !============================
+
+  if (l_turb_standalone.and.masterproc) then
+     close(txtout_unit)
+     call freeunit(txtout_unit)
+  end if
+  !---------------------------------
+   
    ! Transfer back to pbuf variables
 
    do k=1,pver
@@ -1272,5 +1388,210 @@ end function shoc_implements_cnst
     grid_dy = grid_dx
 
   end subroutine grid_size_planar_uniform
+
+  subroutine read_and_set_input_to_shoc_main( &
+             ncol, thv_input, &
+             zt_g_input, zi_g_input, pres_input, presi_input, pdel_input, &
+             wpthlp_sfc_input, wprtp_sfc_input, upwp_sfc_input, vpwp_sfc_input, &
+             inv_exner_input, &
+             tke_zt_input, thlm_input, rtm_input, &
+             um_input, vm_input, &
+             wm_zt_input, &
+             rcm_input, cloud_frac_input, &
+             tkh_input, tk_input &
+             )
+
+    use ppgrid, only: pver, pverp, pcols
+
+    integer, intent(in) :: ncol
+
+    ! For fields read in from SHOC text input files
+
+    real(r8) :: wprtp_sfc_input(pcols)
+    real(r8) :: wpthlp_sfc_input(pcols)
+    real(r8) :: upwp_sfc_input(pcols)
+    real(r8) :: vpwp_sfc_input(pcols)
+    real(r8) :: zsurf
+
+    real(r8) :: zi_g_input(pcols,pverp)
+    real(r8) :: presi_input(pcols,pverp)
+
+    real(r8) :: zt_g_input(pcols,pver)
+    real(r8) :: um_input(pcols,pver)
+    real(r8) :: vm_input(pcols,pver)
+    real(r8) :: wm_zt_input(pcols,pver)
+    real(r8) :: tke_zt_input(pcols,pver)
+    real(r8) :: thv_input(pcols,pver)
+    real(r8) :: thlm_input(pcols,pver)
+    real(r8) :: rtm_input(pcols,pver)
+    real(r8) :: rcm_input(pcols,pver)
+    real(r8) :: pres_input(pcols,pver)
+    real(r8) :: pdel_input(pcols,pver)
+    real(r8) :: inv_exner_input(pcols,pver)
+    real(r8) :: tk_input(pcols,pver)
+    real(r8) :: tkh_input(pcols,pver)
+    real(r8) :: cloud_frac_input(pcols,pver)
+
+    character(len=72) :: junk   ! a string to hold comment lines in input text file
+
+    real(r8) :: wprtp_sfc_read
+    real(r8) :: wpthlp_sfc_read
+    real(r8) :: upwp_sfc_read
+    real(r8) :: vpwp_sfc_read
+    integer  :: pverread
+    integer  :: pverpread
+    real(r8) :: zi_g_read
+    real(r8) :: zt_g_read
+    real(r8) :: dz_zi_read
+    real(r8) :: um_read
+    real(r8) :: vm_read
+    real(r8) :: wm_zt_read
+    real(r8) :: tke_zt_read
+    real(r8) :: thv_read
+    real(r8) :: thlm_read
+    real(r8) :: rtm_read
+    real(r8) :: rcm_read
+    real(r8) :: presi_read
+    real(r8) :: pres_read
+    real(r8) :: pdel_read
+    real(r8) :: inv_exner_read
+    real(r8) :: tk_read
+    real(r8) :: tkh_read
+    real(r8) :: cloud_frac_read
+
+    integer :: kk
+    integer :: k_read
+    integer :: ki_cxx_read
+    integer :: kt_cxx_read
+    integer :: ierr
+    integer :: unitn
+   !integer :: nstep
+
+    if (.not.masterproc) then
+       call endrun('In SCM mode but calculating SHOC on multiple MPI processes?')
+    else
+       !----------------------------------------------------------------
+       ! Surface variables
+       !----------------------------------------------------------------
+       write(iulog,*) 'Read in column surface vars initial conditions.'
+
+       unitn = getunit()
+       open( unitn, file='ShocInOut_IC_surface_vars.txt', status='old' )
+       read( unitn, *, iostat=ierr ) junk
+       if( ierr /= 0 ) then
+          call endrun('Error reading ShocInOut_IC_surface_vars.txt.')
+       end if
+       read( unitn, *, iostat=ierr ) junk
+
+       read(unitn, *)  pverread
+       write(iulog,*) 'pverread is:  ', pverread
+       pverpread = pverread + 1
+
+       read(unitn,*) dz_zi_read      !  dz_zi is computed in subroutine shoc_main/shoc_grid from zi_g, zt_g
+                                     !  So this is not directly used.
+       read(unitn,*) zsurf           !  zsurf, assume zero for now and don't use
+       write(iulog,*) 'zsurf is:  ', zsurf
+
+       read(unitn,*) wprtp_sfc_read  ! kg/kg m/s
+       write(iulog,*) 'wprtp_sfc is:  ',wprtp_sfc_read
+
+       read(unitn,*) wpthlp_sfc_read  ! In SHOC this needs to be in kinematic units (K-m/s); for this input file format, it is
+       write(iulog,*) 'wpthlp_sfc is:  ',wpthlp_sfc_read
+
+       read(unitn,*) upwp_sfc_read
+       write(iulog,*) 'upwp_sfc is:  ',upwp_sfc_read
+
+       read(unitn,*) vpwp_sfc_read
+       write(iulog,*) 'vpwp_sfc is:  ',vpwp_sfc_read
+
+       wprtp_sfc_input(:ncol) = wprtp_sfc_read
+       wpthlp_sfc_input(:ncol) = wpthlp_sfc_read
+       upwp_sfc_input(:ncol) = upwp_sfc_read
+       vpwp_sfc_input(:ncol) = vpwp_sfc_read
+
+       close( unitn )
+       call freeunit( unitn )
+
+       !----------------------------------------------------------------
+       ! Variables at layer interfaces
+       !----------------------------------------------------------------
+       write(iulog,*) 'Read in column zi profile initial conditions.'
+       unitn = getunit()
+       open( unitn, file='ShocInOut_IC_zi_grid.txt', status='old' )
+       read( unitn, *, iostat=ierr ) junk
+       if( ierr /= 0 ) then
+          call endrun('Error reading ShocInOut_IC_zi_grid.txt.')
+       end if
+       read( unitn, * ) junk
+       read( unitn, * ) junk
+
+       !  This in-out exercise only makes sense if pverpread <= pverp, number of E3SM interface levels
+       !  In case pverpread > pverp, only utilize first pverp input values, ignore rest, but still read whole file.
+
+       do k_read=1,pverpread
+        kk = pverp-k_read+1       ! Note that for SHOC k=1 is model top, but input file starts at model surface
+        read(unitn,*) ki_cxx_read, zi_g_read, presi_read   ! first column is interface index, but zero-based as in C++
+        if( (ki_cxx_read+1) .ne. k_read ) then
+          call endrun('Mismatch between interface count and k -- missing value?')
+        else if(kk.ge.1) then
+           zi_g_input(:ncol,kk) = zi_g_read
+           presi_input(:ncol,kk) = presi_read
+           write(iulog,*) kk,zi_g_read,presi_read
+        end if
+       end do
+       close( unitn )
+       call freeunit( unitn )
+
+       !----------------------------------------------------------------
+       ! Variables at layer midpoints
+       !----------------------------------------------------------------
+       write(iulog,*) 'Read in column zt profile initial conditions.'
+       unitn = getunit()
+       open( unitn, file='ShocInOut_IC_zt_grid.txt', status='old' )
+       read( unitn, *, iostat=ierr ) junk
+       if( ierr /= 0 ) then
+          call endrun('Error reading ShocInOut_IC_zt_grid.txt.')
+       end if
+       read( unitn, * ) junk
+       read( unitn, * ) junk
+
+       do k_read=1,pverread
+          kk = pver-k_read+1
+          read(unitn,*) kt_cxx_read, zt_g_read, um_read, vm_read, wm_zt_read, tke_zt_read, thv_read, &
+               thlm_read, rtm_read, rcm_read, pres_read, pdel_read, inv_exner_read, tk_read, tkh_read, &
+               cloud_frac_read     ! first column is level index, but in zero-based indexing as in C++
+
+          if( (kt_cxx_read+1) .ne. k_read ) then
+             call endrun('Mismatch between level count and k -- missing value?')
+          else if(kk.ge.1) then
+              zt_g_input(:ncol,kk) = zt_g_read
+              um_input(:ncol,kk) = um_read
+              vm_input(:ncol,kk) = vm_read
+              wm_zt_input(:ncol,kk) = wm_zt_read
+              tke_zt_input(:ncol,kk) = tke_zt_read
+              thv_input(:ncol,kk) = thv_read
+              thlm_input(:ncol,kk) = thlm_read
+              rtm_input(:ncol,kk) = rtm_read
+              rcm_input(:ncol,kk) = rcm_read
+              pres_input(:ncol,kk) = pres_read
+              pdel_input(:ncol,kk) = pdel_read   !  Assumed to be consistent with presi(kk+1) - presi(kk)
+              inv_exner_input(:ncol,kk) = inv_exner_read  ! Assumed to be consistent with pres(kk) and interface constants
+              tk_input(:ncol,kk) = tk_read
+              !  looks like tk, tkh are effectively intent(out), so initial values not actually used.
+              tkh_input(:ncol,kk) = tkh_read
+              cloud_frac_input(:ncol,kk) = cloud_frac_read
+              write(iulog,*) kk, zt_g_read, um_read, vm_read, wm_zt_read, tke_zt_read, &
+                   thv_read, thlm_read, rtm_read, rcm_read, pres_read, pdel_read, &
+                   inv_exner_read, tk_read, tkh_read, cloud_frac_read
+           end if
+
+       end do
+
+       close( unitn )
+       call freeunit( unitn )
+
+    end if ! masterproc
+
+  end subroutine read_and_set_input_to_shoc_main
 
 end module shoc_intr

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -95,6 +95,9 @@ module shoc_intr
 
   real(r8), parameter :: unset_r8 = huge(1.0_r8)
 
+  real(r8) :: host_dx_dy_nml = unset_r8    ! Host model's horizontal grid spacing (m) read from namelist.
+                                           ! This variable is used only in SCM mode.
+
   real(r8) :: shoc_timestep = unset_r8  ! Default SHOC timestep set in namelist
   real(r8) :: dp1
 
@@ -338,7 +341,12 @@ end function shoc_implements_cnst
                       l_turb_standalone_out=l_turb_standalone, &
                       history_amwg_out = history_amwg, &
                       turb_nadv_out_nstep_out = turb_nadv_out_nstep, &
+                      host_dx_dy_out  = host_dx_dy_nml, &
                       liqcf_fix_out   = liqcf_fix)
+
+    write(iulog,*) 'shoc_init_e3sm: l_turb_standalone   = ',l_turb_standalone
+    write(iulog,*) 'shoc_init_e3sm: host_dx_dy_nml      = ',host_dx_dy_nml
+    write(iulog,*) 'shoc_init_e3sm: turb_nadv_out_nstep = ',turb_nadv_out_nstep
 
     ! Define physics buffers indexes
     cld_idx     = pbuf_get_index('CLD')         ! Cloud fraction
@@ -774,8 +782,8 @@ end function shoc_implements_cnst
    ! Set grid space, in meters. If SCM, set to a grid size representative
    !  of a typical GCM.  Otherwise, compute locally.
    if (single_column .and. .not. dp_crm) then
-     host_dx_in(:) = 100000._r8
-     host_dy_in(:) = 100000._r8
+     host_dx_in(:) = host_dx_dy_nml
+     host_dy_in(:) = host_dx_dy_nml
    else if (dp_crm) then
      call grid_size_planar_uniform(host_dx, host_dy)
      host_dx_in(:) = host_dx

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -647,7 +647,7 @@ end function shoc_implements_cnst
    real(r8) :: liq_cloud_frac(pcols,pver)
    real(r8) :: dlf2(pcols,pver)
    real(r8) :: isotropy(pcols,pver)
-   real(r8) :: host_dx, host_dy
+   real(r8) :: host_dx_crm, host_dy_crm
    real(r8) :: host_temp(pcols,pver)
    real(r8) :: host_dx_in(pcols), host_dy_in(pcols)
    real(r8) :: shoc_mix_out(pcols,pver), tk_in(pcols,pver), tkh_in(pcols,pver)
@@ -819,9 +819,9 @@ end function shoc_implements_cnst
      host_dx_in(:) = host_dx_dy_nml
      host_dy_in(:) = host_dx_dy_nml
    else if (dp_crm) then
-     call grid_size_planar_uniform(host_dx, host_dy)
-     host_dx_in(:) = host_dx
-     host_dy_in(:) = host_dy
+     call grid_size_planar_uniform(host_dx_crm, host_dy_crm)
+     host_dx_in(:) = host_dx_crm
+     host_dy_in(:) = host_dy_crm
    else
      call grid_size(state1, host_dx_in, host_dy_in)
    endif


### PR DESCRIPTION
- default value is 1e5 (unit: m)
- used in both shoc_intr.F90 and clubb_intr.F90
- during initialization, a line like the following is added to atm.log:

 `shoc_init_e3sm: host_dx_dy_nml      =    100000.000000000`