### PR TITLE
Code refactoring for "in-and-out" simulations

### DIFF
--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -3816,6 +3816,8 @@ if ($shoc_sgs  =~ /$TRUE/io) {
    add_default($nl, 'shoc_Ckm');
    add_default($nl, 'shoc_Ckh_s');
    add_default($nl, 'shoc_Ckm_s');
+   add_default($nl, 'shoc_output_prefix');
+   add_default($nl, 'l_shoc_outer_loop');
 }
 
 

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -833,6 +833,8 @@
 <shoc_Ckm                    > 0.1D0 </shoc_Ckm>
 <shoc_Ckh_s                  > 0.1D0 </shoc_Ckh_s>
 <shoc_Ckm_s                  > 0.1D0 </shoc_Ckm_s>
+<shoc_output_prefix          > '' </shoc_output_prefix>
+<l_shoc_outer_loop           > .true. </l_shoc_outer_loop>
 
 <!-- CLUBB options -->
 <clubb_rainevap_turb                              > .false. </clubb_rainevap_turb>

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -3445,6 +3445,22 @@ Coefficient for eddy diffusivity for momentum for stable boundary layers.
 Default: set by build-namelist
 </entry>
 
+<entry id="shoc_output_prefix" type="char*256" category="pblrad"
+       group="shocpbl_diff_nl" valid_values="" >
+Prefix for SHOC text output filenames used in in-and-out experiments.
+When set, output files are named {prefix}_nadv{N}x{M}_exp{1|2}.txt.
+When empty (default), the old hardcoded filenames are used.
+Default: ''
+</entry>
+
+<entry id="l_shoc_outer_loop" type="logical" category="pblrad"
+       group="shocpbl_diff_nl" valid_values="" >
+Controls in-and-out experiment mode for SHOC.
+  .false. = experiment 1: single shoc_main call with large nadv (output from shoc.F90)
+  .true.  = experiment 2: many shoc_main calls with nadv=1 (output from shoc_intr.F90)
+Default: .true.
+</entry>
+
 <entry id="clubb_cloudtop_cooling" type="logical"  category="pblrad"
        group="clubbpbl_diff_nl" valid_values="" >
 Apply cloud top radiative cooling parameterization

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -3448,8 +3448,8 @@ Default: set by build-namelist
 <entry id="shoc_output_prefix" type="char*256" category="pblrad"
        group="shocpbl_diff_nl" valid_values="" >
 Prefix for SHOC text output filenames used in in-and-out experiments.
-When set, output files are named {prefix}_nadv{N}x{M}_exp{1|2}.txt.
-When empty (default), the old hardcoded filenames are used.
+Output files are named {prefix}_nadv{N}_x_shocm{M}_nstep{NSTEPS}_macmicsub{MACMICSUB}.txt.
+When empty (default), a built-in prefix 'shoc_output' is used.
 Default: ''
 </entry>
 

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -15,7 +15,6 @@ module shoc
   use physics_utils, only: rtype, rtype8, itype, btype
   use scream_abortutils, only: endscreamrun
   use spmd_utils, only: masterproc
-  use cam_logfile, only: iulog
 
 ! Bit-for-bit math functions.
 #ifdef SCREAM_CONFIG_IS_CMAKE
@@ -225,7 +224,7 @@ end subroutine shoc_init
 ! Host models should call the following routine to call SHOC
 
 subroutine shoc_main ( &
-     unitn_out, &                         ! Input
+     l_txt_write, txtout_unit, &          ! Input
      turb_nadv_out_nstep, lchnk, &        ! Input
      shcol, nlev, nlevi, dtime, nadv, &   ! Input
      host_dx, host_dy,thv, &              ! Input
@@ -258,7 +257,8 @@ subroutine shoc_main ( &
 
 ! INPUT VARIABLES
 
-  integer, intent(in) :: unitn_out
+  logical, intent(in) :: l_txt_write         ! Whether results will be written out to a txt file within the nadv loop
+  integer, intent(in) :: txtout_unit         ! File handle for txt output
   integer, intent(in) :: turb_nadv_out_nstep ! # of time steps (in this subr.) to write out fields for
   integer, intent(in) :: lchnk               ! chunk ID related to the host model's domain decomposition
 
@@ -414,20 +414,7 @@ subroutine shoc_main ( &
               se_a(shcol),ke_a(shcol),&
               wv_a(shcol),wl_a(shcol)
 
-  ! Variables for SHOC text output
-
   integer :: kk
-  integer :: time_output
-  integer :: ilay_output
-  real(rtype) :: u_output
-  real(rtype) :: v_output
-  real(rtype) :: tke_output
-  real(rtype) :: qv_output
-  real(rtype) :: qc_output
-  real(rtype) :: t_output
-  real(rtype) :: p_output
-
-
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
   integer :: clock_count1, clock_count_rate, clock_count_max, clock_count2, clock_count_diff
@@ -458,7 +445,6 @@ subroutine shoc_main ( &
 #ifdef SCREAM_CONFIG_IS_CMAKE
     call system_clock(clock_count1, clock_count_rate, clock_count_max)
 #endif
-
 
   ! Compute integrals of static energy, kinetic energy, water vapor, and liquid water
   ! for the computation of total energy before SHOC is called.  This is for an
@@ -589,27 +575,23 @@ subroutine shoc_main ( &
        call outfld('SHOC_TKE'//trim(adjustl(numstr)),         tke,shcol,lchnk)
        call outfld(  'THETAL'//trim(adjustl(numstr)),      thetal,shcol,lchnk)
        call outfld( 'CLDFRAC'//trim(adjustl(numstr)),shoc_cldfrac,shcol,lchnk)
+    end if
 
-          ! Write out fields to SHOC text output file (exp1)
+    !---------------------------------------------
+    ! Write out fields to SHOC text output file
 
-   if(masterproc) then
+    if (l_txt_write.and.masterproc) then
       do kk=nlev,1,-1
-         time_output =  t * nint(dtime)
-         ilay_output =  kk-1   !  ilay is in C++ indexing convention
-         u_output = u_wind(1,kk)
-         v_output = v_wind(1,kk)
-         tke_output = tke(1,kk)
-         qv_output = qw(1,kk) - shoc_ql(1,kk)
-         qc_output = shoc_ql(1,kk)
-         t_output = thetal(1,kk) / inv_exner(1,kk) + lcond/cp * shoc_ql(1,kk)
-         p_output = pres(1,kk)
-         write(unitn_out,fmt) time_output, ilay_output, u_output, v_output, tke_output, qv_output, qc_output, t_output, p_output
+         write(txtout_unit,fmt) t*nint(dtime),                                           &! time elapsed inside this subroutine 
+                                kk-1,                                                    &! vertical layer index (upward, starting from 0)
+                                u_wind(1,kk), v_wind(1,kk), tke(1,kk),                   &! u, v, and tke
+                                    qw(1,kk)-shoc_ql(1,kk),                              &! qv
+                               shoc_ql(1,kk),                                            &! qc
+                                thetal(1,kk)/inv_exner(1,kk) + lcond/cp * shoc_ql(1,kk), &! temperature
+                                  pres(1,kk)                                              ! pressure
       end do
-   end if
-
     end if
     !---------------------------------------------
-
 
   enddo ! end time loop
 

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -16,6 +16,7 @@ module shoc
   use scream_abortutils, only: endscreamrun
   use spmd_utils, only: masterproc
   use cam_logfile, only: iulog
+  use units, only: getunit, freeunit
 
 ! Bit-for-bit math functions.
 #ifdef SCREAM_CONFIG_IS_CMAKE
@@ -410,9 +411,10 @@ subroutine shoc_main ( &
               se_a(shcol),ke_a(shcol),&
               wv_a(shcol),wl_a(shcol)
 
-  ! Variables for SHOC text output 
+  ! Variables for SHOC text output
 
   integer :: kk
+  integer :: unitn_out
   integer :: time_output
   integer :: ilay_output
   real(rtype) :: u_output
@@ -464,6 +466,13 @@ subroutine shoc_main ( &
      shcol,nlev,host_dse,pdel,&             ! Input
      qw,shoc_ql,u_wind,v_wind,&             ! Input
      se_b,ke_b,wv_b,wl_b)                   ! Input/Output
+
+  ! Open output file for SHOC text output (experiment 1)
+  if(masterproc .and. turb_nadv_out_nstep.gt.0) then
+     unitn_out = getunit()
+     open(unitn_out, file='shoc_output_nadv360x1.txt', status='replace')
+     write(unitn_out,*) 'time, ilay, u, v, tke, qv, qc, T, P'
+  end if
 
   do t=1,nadv
 
@@ -586,16 +595,11 @@ subroutine shoc_main ( &
        call outfld(  'THETAL'//trim(adjustl(numstr)),      thetal,shcol,lchnk)
        call outfld( 'CLDFRAC'//trim(adjustl(numstr)),shoc_cldfrac,shcol,lchnk)
 
-          ! Write out fields in specified format.
-          ! Output file will just be named 'fort.102'.
+          ! Write out fields to shoc_output_nadv360x1.txt
 
    if(masterproc) then
-
-      if(t.eq.1) then 
-           write(102,*) 'time, ilay, u, v, tke, qv, qc, T, P'
-      end if     
       do kk=nlev,1,-1
-         time_output =  t * 60  
+         time_output =  t * 60
          ilay_output =  kk-1   !  ilay is in C++ indexing convention
          u_output = u_wind(1,kk)
          v_output = v_wind(1,kk)
@@ -604,9 +608,8 @@ subroutine shoc_main ( &
          qc_output = shoc_ql(1,kk)
          t_output = thetal(1,kk) / inv_exner(1,kk) + lcond/cp * shoc_ql(1,kk)
          p_output = pres(1,kk)
-         write(102,104) time_output, ilay_output, u_output, v_output, tke_output, qv_output, qc_output, t_output, p_output
+         write(unitn_out,104) time_output, ilay_output, u_output, v_output, tke_output, qv_output, qc_output, t_output, p_output
       end do
-
    end if
 
 104       format(I5,1X,I4,5(1X,F17.14),1X,F16.12,1X,F17.10)
@@ -620,6 +623,12 @@ subroutine shoc_main ( &
 
 
   enddo ! end time loop
+
+  ! Close output file
+  if(masterproc .and. turb_nadv_out_nstep.gt.0) then
+     close(unitn_out)
+     call freeunit(unitn_out)
+  end if
 
   ! End SHOC parameterization
 

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -37,6 +37,8 @@ character(len=256), public :: shoc_output_prefix = ''
 real(rtype), parameter, public :: largeneg = -99999999.99_rtype
 real(rtype), parameter, public :: pi = 3.14159265358979323_rtype
 
+!character(len=*), parameter, public :: fmt = '(i8,i4,20ES22.13)'
+character(len=*), parameter, public :: fmt = '(I5,1X,I4,5(1X,F17.14),1X,F16.12,1X,F17.10)'
 !=========================================================
 ! Physical constants used in SHOC
 !=========================================================
@@ -617,15 +619,9 @@ subroutine shoc_main ( &
          qc_output = shoc_ql(1,kk)
          t_output = thetal(1,kk) / inv_exner(1,kk) + lcond/cp * shoc_ql(1,kk)
          p_output = pres(1,kk)
-         write(unitn_out,104) time_output, ilay_output, u_output, v_output, tke_output, qv_output, qc_output, t_output, p_output
+         write(unitn_out,fmt) time_output, ilay_output, u_output, v_output, tke_output, qv_output, qc_output, t_output, p_output
       end do
    end if
-
-104       format(I5,1X,I4,5(1X,F17.14),1X,F16.12,1X,F17.10)
-
-
-
-
 
     end if
     !---------------------------------------------

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -31,6 +31,9 @@ public  :: shoc_init, shoc_main
 
 logical :: use_cxx = .true.
 
+! Prefix for SHOC text output filenames (set via namelist shoc_output_prefix)
+character(len=256), public :: shoc_output_prefix = ''
+
 real(rtype), parameter, public :: largeneg = -99999999.99_rtype
 real(rtype), parameter, public :: pi = 3.14159265358979323_rtype
 
@@ -417,6 +420,7 @@ subroutine shoc_main ( &
   integer :: unitn_out
   integer :: time_output
   integer :: ilay_output
+  character(len=512) :: outfname
   real(rtype) :: u_output
   real(rtype) :: v_output
   real(rtype) :: tke_output
@@ -470,7 +474,12 @@ subroutine shoc_main ( &
   ! Open output file for SHOC text output (experiment 1)
   if(masterproc .and. turb_nadv_out_nstep.gt.0) then
      unitn_out = getunit()
-     open(unitn_out, file='shoc_output_nadv360x1.txt', status='replace')
+     if (len_trim(shoc_output_prefix) > 0) then
+        write(outfname, '(A,A,I0,A)') trim(shoc_output_prefix), '_nadv', nadv, 'x1_exp1.txt'
+     else
+        outfname = 'shoc_output_nadv360x1.txt'
+     end if
+     open(unitn_out, file=trim(outfname), status='replace')
      write(unitn_out,*) 'time, ilay, u, v, tke, qv, qc, T, P'
   end if
 
@@ -595,11 +604,11 @@ subroutine shoc_main ( &
        call outfld(  'THETAL'//trim(adjustl(numstr)),      thetal,shcol,lchnk)
        call outfld( 'CLDFRAC'//trim(adjustl(numstr)),shoc_cldfrac,shcol,lchnk)
 
-          ! Write out fields to shoc_output_nadv360x1.txt
+          ! Write out fields to SHOC text output file (exp1)
 
    if(masterproc) then
       do kk=nlev,1,-1
-         time_output =  t * 60
+         time_output =  t * nint(dtime)
          ilay_output =  kk-1   !  ilay is in C++ indexing convention
          u_output = u_wind(1,kk)
          v_output = v_wind(1,kk)

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -583,7 +583,7 @@ subroutine shoc_main ( &
     if (l_txt_write.and.masterproc) then
       do kk=nlev,1,-1
          write(txtout_unit,fmt) t*nint(dtime),                                           &! time elapsed inside this subroutine 
-                                kk-1,                                                    &! vertical layer index (upward, starting from 0)
+                                kk-1,                                                    &! vertical layer index (0 = TOM, nlev - 1 = sfc)
                                 u_wind(1,kk), v_wind(1,kk), tke(1,kk),                   &! u, v, and tke
                                     qw(1,kk)-shoc_ql(1,kk),                              &! qv
                                shoc_ql(1,kk),                                            &! qc

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -16,7 +16,6 @@ module shoc
   use scream_abortutils, only: endscreamrun
   use spmd_utils, only: masterproc
   use cam_logfile, only: iulog
-  use units, only: getunit, freeunit
 
 ! Bit-for-bit math functions.
 #ifdef SCREAM_CONFIG_IS_CMAKE
@@ -30,9 +29,6 @@ save ! for module variables
 public  :: shoc_init, shoc_main
 
 logical :: use_cxx = .true.
-
-! Prefix for SHOC text output filenames (set via namelist shoc_output_prefix)
-character(len=256), public :: shoc_output_prefix = ''
 
 real(rtype), parameter, public :: largeneg = -99999999.99_rtype
 real(rtype), parameter, public :: pi = 3.14159265358979323_rtype
@@ -229,6 +225,7 @@ end subroutine shoc_init
 ! Host models should call the following routine to call SHOC
 
 subroutine shoc_main ( &
+     unitn_out, &                         ! Input
      turb_nadv_out_nstep, lchnk, &        ! Input
      shcol, nlev, nlevi, dtime, nadv, &   ! Input
      host_dx, host_dy,thv, &              ! Input
@@ -261,6 +258,7 @@ subroutine shoc_main ( &
 
 ! INPUT VARIABLES
 
+  integer, intent(in) :: unitn_out
   integer, intent(in) :: turb_nadv_out_nstep ! # of time steps (in this subr.) to write out fields for
   integer, intent(in) :: lchnk               ! chunk ID related to the host model's domain decomposition
 
@@ -419,10 +417,8 @@ subroutine shoc_main ( &
   ! Variables for SHOC text output
 
   integer :: kk
-  integer :: unitn_out
   integer :: time_output
   integer :: ilay_output
-  character(len=512) :: outfname
   real(rtype) :: u_output
   real(rtype) :: v_output
   real(rtype) :: tke_output
@@ -472,18 +468,6 @@ subroutine shoc_main ( &
      shcol,nlev,host_dse,pdel,&             ! Input
      qw,shoc_ql,u_wind,v_wind,&             ! Input
      se_b,ke_b,wv_b,wl_b)                   ! Input/Output
-
-  ! Open output file for SHOC text output (experiment 1)
-  if(masterproc .and. turb_nadv_out_nstep.gt.0) then
-     unitn_out = getunit()
-     if (len_trim(shoc_output_prefix) > 0) then
-        write(outfname, '(A,A,I0,A)') trim(shoc_output_prefix), '_nadv', nadv, 'x1_exp1.txt'
-     else
-        outfname = 'shoc_output_nadv360x1.txt'
-     end if
-     open(unitn_out, file=trim(outfname), status='replace')
-     write(unitn_out,*) 'time, ilay, u, v, tke, qv, qc, T, P'
-  end if
 
   do t=1,nadv
 
@@ -628,12 +612,6 @@ subroutine shoc_main ( &
 
 
   enddo ! end time loop
-
-  ! Close output file
-  if(masterproc .and. turb_nadv_out_nstep.gt.0) then
-     close(unitn_out)
-     call freeunit(unitn_out)
-  end if
 
   ! End SHOC parameterization
 

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -14,6 +14,8 @@ module shoc
 
   use physics_utils, only: rtype, rtype8, itype, btype
   use scream_abortutils, only: endscreamrun
+  use spmd_utils, only: masterproc
+  use cam_logfile, only: iulog
 
 ! Bit-for-bit math functions.
 #ifdef SCREAM_CONFIG_IS_CMAKE
@@ -408,6 +410,21 @@ subroutine shoc_main ( &
               se_a(shcol),ke_a(shcol),&
               wv_a(shcol),wl_a(shcol)
 
+  ! Variables for SHOC text output 
+
+  integer :: kk
+  integer :: time_output
+  integer :: ilay_output
+  real(rtype) :: u_output
+  real(rtype) :: v_output
+  real(rtype) :: tke_output
+  real(rtype) :: qv_output
+  real(rtype) :: qc_output
+  real(rtype) :: t_output
+  real(rtype) :: p_output
+
+
+
 #ifdef SCREAM_CONFIG_IS_CMAKE
   integer :: clock_count1, clock_count_rate, clock_count_max, clock_count2, clock_count_diff
 #endif
@@ -437,6 +454,7 @@ subroutine shoc_main ( &
 #ifdef SCREAM_CONFIG_IS_CMAKE
     call system_clock(clock_count1, clock_count_rate, clock_count_max)
 #endif
+
 
   ! Compute integrals of static energy, kinetic energy, water vapor, and liquid water
   ! for the computation of total energy before SHOC is called.  This is for an
@@ -567,8 +585,39 @@ subroutine shoc_main ( &
        call outfld('SHOC_TKE'//trim(adjustl(numstr)),         tke,shcol,lchnk)
        call outfld(  'THETAL'//trim(adjustl(numstr)),      thetal,shcol,lchnk)
        call outfld( 'CLDFRAC'//trim(adjustl(numstr)),shoc_cldfrac,shcol,lchnk)
+
+          ! Write out fields in specified format.
+          ! Output file will just be named 'fort.102'.
+
+   if(masterproc) then
+
+      if(t.eq.1) then 
+           write(102,*) 'time, ilay, u, v, tke, qv, qc, T, P'
+      end if     
+      do kk=nlev,1,-1
+         time_output =  t * 60  
+         ilay_output =  kk-1   !  ilay is in C++ indexing convention
+         u_output = u_wind(1,kk)
+         v_output = v_wind(1,kk)
+         tke_output = tke(1,kk)
+         qv_output = qw(1,kk) - shoc_ql(1,kk)
+         qc_output = shoc_ql(1,kk)
+         t_output = thetal(1,kk) / inv_exner(1,kk) + lcond/cp * shoc_ql(1,kk)
+         p_output = pres(1,kk)
+         write(102,104) time_output, ilay_output, u_output, v_output, tke_output, qv_output, qc_output, t_output, p_output
+      end do
+
+   end if
+
+104       format(I5,1X,I4,5(1X,F17.14),1X,F16.12,1X,F17.10)
+
+
+
+
+
     end if
     !---------------------------------------------
+
 
   enddo ! end time loop
 

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -934,6 +934,8 @@ end function shoc_implements_cnst
              ncol, thv, zt_g, zi_g, state1%pmid, state1%pint, state1%pdel, &
              wpthlp_sfc, wprtp_sfc, upwp_sfc, vpwp_sfc, inv_exner, tke_zt, &
              thlm, rtm, um, vm, wm_zt, rcm, cloud_frac, tkh, tk )
+
+      wthv(:ncol,:) = 0.0_r8
    end if
 
    ! Open txt file for output

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -29,6 +29,7 @@ module shoc_intr
   use cam_abortutils, only: endrun
   use iop_data_mod,   only: single_column
   use units, only:  getunit, freeunit
+  use time_manager,  only: get_nstep
 
   implicit none
 
@@ -943,7 +944,9 @@ end function shoc_implements_cnst
 
       txt_output_prefix = 'shoc_output'
       if (len_trim(shoc_output_prefix) > 0) txt_output_prefix = trim(shoc_output_prefix)
-      write(outfname, '(A,A,I0,A,I0,A)') trim(txt_output_prefix), '_nadv', nadv, '_x_shocm', n_shoc_main_calls, '.txt'
+      write(outfname, '(A,3(A,I0),A)') trim(txt_output_prefix), &
+                                       '_nadv', nadv, '_x_shocm',n_shoc_main_calls, &
+                                       '_nstep',get_nstep(), '.txt'
 
       ! Open txt file and write a header
 

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -928,9 +928,9 @@ end function shoc_implements_cnst
    !----------------------------------------------------------------------------------
    ! Initialization/preparation for "standalone"/"in-and-out" test (only in SCM mode)
    !----------------------------------------------------------------------------------
-   ! Overwrite values of shoc_main's input variables using values from txt files
-
    if (l_turb_standalone) then
+
+      ! Overwrite values of shoc_main's input variables using values from txt files
 
       call read_and_set_input_to_shoc_main( &
              ncol, thv, zt_g, zi_g, state1%pmid, state1%pint, state1%pdel, &
@@ -938,43 +938,39 @@ end function shoc_implements_cnst
              thlm, rtm, um, vm, wm_zt, rcm, cloud_frac, tkh, tk )
 
       wthv(:ncol,:) = 0.0_r8
-   end if
 
-   ! Open txt file for output
+      if (masterproc) then
 
-   if (single_column.and.masterproc) then
+         ! Determine name of txt output file
 
-      ! Determine name of txt output file
+         txt_output_prefix = 'shoc_output'
+         if (len_trim(shoc_output_prefix) > 0) txt_output_prefix = trim(shoc_output_prefix)
+         write(outfname, '(A,4(A,I0),A)') trim(txt_output_prefix), &
+                                          '_nadv', nadv, '_x_shocm',n_shoc_main_calls, &
+                                          '_nstep',get_nstep(), '_macmicsub',macmic_it,&
+                                          '.txt'
 
-      txt_output_prefix = 'shoc_output'
-      if (len_trim(shoc_output_prefix) > 0) txt_output_prefix = trim(shoc_output_prefix)
-      write(outfname, '(A,4(A,I0),A)') trim(txt_output_prefix), &
-                                       '_nadv', nadv, '_x_shocm',n_shoc_main_calls, &
-                                       '_nstep',get_nstep(), '_macmicsub',macmic_it,&
-                                       '.txt'
+         ! Open txt file and write a header
 
-      ! Open txt file and write a header
+         txtout_unit = getunit()
+         open(txtout_unit, file=trim(outfname), status='replace')
+         write(txtout_unit,*) 'time, k (0 = TOM, pver - 1 = sfc), u, v, tke, qv, qc, T, P'
 
-      txtout_unit = getunit()
-      open(txtout_unit, file=trim(outfname), status='replace')
-      write(txtout_unit,*) 'time, k (0 = TOM, pver - 1 = sfc), u, v, tke, qv, qc, T, P'
+         ! Send info to iulog to double check
 
-      ! Send info to iulog to double check
+         write(iulog,*) 'shoc_num_steps    = ', shoc_num_steps
+         write(iulog,*) 'n_shoc_main_calls = ', n_shoc_main_calls
+         write(iulog,*) 'nadv              = ', nadv
 
-     !write(iulog,*) 'host_dx value:  ', host_dx_in, ' to be set to ', host_dx_input
-     !write(iulog,*) 'host_dy value:  ', host_dy_in, ' to be set to ', host_dy_input
+      end if  ! masterproc
 
-      write(iulog,*) 'shoc_num_steps    = ', shoc_num_steps
-      write(iulog,*) 'n_shoc_main_calls = ', n_shoc_main_calls
-      write(iulog,*) 'nadv              = ', nadv
-
-   end if ! single_column.and.masterproc
+   end if ! l_turb_standalone
 
    ! Write statement inside shoc_main will only be executed when the simulation
    ! is run in an SCM "turb standalone" model when the nadv loop inside shoc_main
    ! is used to take multiple substeps.
 
-   l_inner_write = single_column.and.(.not.l_shoc_outer_loop)
+   l_inner_write = l_turb_standalone .and. (.not.l_shoc_outer_loop)
 
    ! ------------------------------------------------- !
    ! Actually call SHOC                                !
@@ -1006,9 +1002,9 @@ end function shoc_implements_cnst
            uw_sec_out(:ncol,:), vw_sec_out(:ncol,:), w3_out(:ncol,:), & ! Output (diagnostic)
            wqls_out(:ncol,:),brunt_out(:ncol,:),rcm2(:ncol,:)) ! Output (diagnostic)
 
-      ! Write results to txt file after each shoc_main call
+      ! Write results to txt file after each shoc_main call if conditions are met.
 
-      if (single_column.and.l_shoc_outer_loop.and.masterproc) then
+      if (l_turb_standalone .and. l_shoc_outer_loop .and. masterproc) then
            do kk = pver, 1, -1
               write(txtout_unit,fmt) i_shoc_main * nint(dtime), &!
                                      kk - 1,                    &! 0 = TOM, pver - 1 = sfc
@@ -1025,7 +1021,7 @@ end function shoc_implements_cnst
   end do  ! end i_shoc_main loop
   !============================
 
-  if (single_column.and.masterproc) then
+  if (l_turb_standalone.and.masterproc) then
      close(txtout_unit)
      call freeunit(txtout_unit)
   end if

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -91,6 +91,12 @@ module shoc_intr
   logical            :: l_turb_standalone  ! .t. = use EAM's code infrastructure but test SHOC in
                                            ! a single-column standalone mode
 
+  logical            :: l_shoc_outer_loop = .false.
+                                           ! .false. = experiment 1: single shoc_main call with nadv=360,
+                                           !           output written inside shoc.F90 (shoc_output_nadv360x1.txt)
+                                           ! .true.  = experiment 2: 360 shoc_main calls with nadv=1,
+                                           !           output written from shoc_intr (shoc_output_nadv1x360.txt)
+
   character(len=16)  :: eddy_scheme      ! Default set in phys_control.F90
   character(len=16)  :: deep_scheme      ! Default set in phys_control.F90
 
@@ -716,7 +722,10 @@ end function shoc_implements_cnst
   integer :: kt_cxx_read
   integer :: ierr
   integer :: unitn
+  integer :: unitn_out
   integer :: nstep
+  integer :: t_outer
+  integer :: n_outer_steps
 
   integer :: time_output
   integer :: ilay_output
@@ -1002,8 +1011,14 @@ end function shoc_implements_cnst
 
   host_dx_input(:) = 1000._r8
   host_dy_input(:) = 1000._r8
-!  nadv_input = 100
-  nadv_input = 360 
+
+  if (l_shoc_outer_loop) then
+     nadv_input = 1
+     n_outer_steps = 360
+  else
+     nadv_input = 360
+     n_outer_steps = 1
+  end if
 
   
    if(masterproc) then
@@ -1113,29 +1128,96 @@ end function shoc_implements_cnst
          
    end if
     
-   !  In call to shoc_main, use _input variables in place of the default variables 
-      
-     
-   call shoc_main( &
-        turb_nadv_out_nstep, lchnk, & ! Input
-        ncol, pver, pverp, dtime, nadv_input, & ! Input
-        host_dx_input(:ncol), host_dy_input(:ncol), thv_input(:ncol,:),& ! Input
-        zt_g_input(:ncol,:pver), zi_g_input(:ncol,:pverp), pres_input(:ncol,:pver), presi_input(:ncol,:pverp), pdel_input(:ncol,:pver),& ! Input
-        wpthlp_sfc_input(:ncol), wprtp_sfc_input(:ncol), upwp_sfc_input(:ncol), vpwp_sfc_input(:ncol), & ! Input
-        wtracer_sfc(:ncol,:), edsclr_dim, wm_zt_input(:ncol,:), & ! Input
-        inv_exner_input(:ncol,:),state1%phis(:ncol), & ! Input
-        shoc_s(:ncol,:), tke_zt_input(:ncol,:), thlm_input(:ncol,:), rtm_input(:ncol,:), & ! Input/Ouput
-        um_input(:ncol,:), vm_input(:ncol,:), edsclr_in(:ncol,:,:), & ! Input/Output
-        wthv(:ncol,:),tkh_input(:ncol,:),tk_input(:ncol,:), & ! Input/Output
-        rcm_input(:ncol,:),cloud_frac_input(:ncol,:), & ! Input/Output
-        pblh(:ncol), & ! Output
-        shoc_mix_out(:ncol,:), isotropy_out(:ncol,:), & ! Output (diagnostic)
-        w_sec_out(:ncol,:), thl_sec_out(:ncol,:), qw_sec_out(:ncol,:), qwthl_sec_out(:ncol,:), & ! Output (diagnostic)
-        wthl_sec_out(:ncol,:), wqw_sec_out(:ncol,:), wtke_sec_out(:ncol,:), & ! Output (diagnostic)
-        uw_sec_out(:ncol,:), vw_sec_out(:ncol,:), w3_out(:ncol,:), & ! Output (diagnostic)
-        wqls_out(:ncol,:),brunt_out(:ncol,:),rcm2(:ncol,:)) ! Output (diagnostic)
+   !  In call to shoc_main, use _input variables in place of the default variables
+   !
+   !  l_shoc_outer_loop = .false. (experiment 1):
+   !    Single shoc_main call with nadv=360. Output written inside shoc.F90 (shoc_output_nadv360x1.txt)
+   !  l_shoc_outer_loop = .true.  (experiment 2):
+   !    360 shoc_main calls with nadv=1. Output written here (shoc_output_nadv1x360.txt)
 
-   ! for '_input' that happend to be intent(inout), assign the output values to the variables the rest of the code is expecting.
+   if (l_shoc_outer_loop) then
+
+      ! Experiment 2: outer loop with nadv=1, output file from shoc_intr
+      ! Suppress the write inside shoc.F90 by passing turb_nadv_out_nstep=0
+
+      if(masterproc) then
+         unitn_out = getunit()
+         open(unitn_out, file='shoc_output_nadv1x360.txt', status='replace')
+         write(unitn_out,*) 'time, ilay, u, v, tke, qv, qc, T, P'
+      end if
+
+      do t_outer = 1, n_outer_steps
+
+        call shoc_main( &
+             0, lchnk, & ! Input (turb_nadv_out_nstep=0 to suppress internal write)
+             ncol, pver, pverp, dtime, nadv_input, & ! Input
+             host_dx_input(:ncol), host_dy_input(:ncol), thv_input(:ncol,:),& ! Input
+             zt_g_input(:ncol,:pver), zi_g_input(:ncol,:pverp), pres_input(:ncol,:pver), presi_input(:ncol,:pverp), pdel_input(:ncol,:pver),& ! Input
+             wpthlp_sfc_input(:ncol), wprtp_sfc_input(:ncol), upwp_sfc_input(:ncol), vpwp_sfc_input(:ncol), & ! Input
+             wtracer_sfc(:ncol,:), edsclr_dim, wm_zt_input(:ncol,:), & ! Input
+             inv_exner_input(:ncol,:),state1%phis(:ncol), & ! Input
+             shoc_s(:ncol,:), tke_zt_input(:ncol,:), thlm_input(:ncol,:), rtm_input(:ncol,:), & ! Input/Ouput
+             um_input(:ncol,:), vm_input(:ncol,:), edsclr_in(:ncol,:,:), & ! Input/Output
+             wthv(:ncol,:),tkh_input(:ncol,:),tk_input(:ncol,:), & ! Input/Output
+             rcm_input(:ncol,:),cloud_frac_input(:ncol,:), & ! Input/Output
+             pblh(:ncol), & ! Output
+             shoc_mix_out(:ncol,:), isotropy_out(:ncol,:), & ! Output (diagnostic)
+             w_sec_out(:ncol,:), thl_sec_out(:ncol,:), qw_sec_out(:ncol,:), qwthl_sec_out(:ncol,:), & ! Output (diagnostic)
+             wthl_sec_out(:ncol,:), wqw_sec_out(:ncol,:), wtke_sec_out(:ncol,:), & ! Output (diagnostic)
+             uw_sec_out(:ncol,:), vw_sec_out(:ncol,:), w3_out(:ncol,:), & ! Output (diagnostic)
+             wqls_out(:ncol,:),brunt_out(:ncol,:),rcm2(:ncol,:)) ! Output (diagnostic)
+
+        ! Write output variables after each shoc_main call
+        if(masterproc) then
+           do kk = pver, 1, -1
+              time_output = t_outer * 60
+              ilay_output = kk - 1
+              u_output = um_input(1,kk)
+              v_output = vm_input(1,kk)
+              tke_output = tke_zt_input(1,kk)
+              qv_output = rtm_input(1,kk) - rcm_input(1,kk)
+              qc_output = rcm_input(1,kk)
+              t_output = thlm_input(1,kk) / inv_exner_input(1,kk) + latvap/cpair * rcm_input(1,kk)
+              p_output = pres_input(1,kk)
+              write(unitn_out,104) time_output, ilay_output, u_output, v_output, tke_output, qv_output, qc_output, t_output, p_output
+           end do
+        end if
+
+      end do  ! end t_outer loop
+
+104   format(I5,1X,I4,5(1X,F17.14),1X,F16.12,1X,F17.10)
+
+      if(masterproc) then
+         close(unitn_out)
+         call freeunit(unitn_out)
+      end if
+
+   else
+
+      ! Experiment 1: single shoc_main call with nadv=360, output written inside shoc.F90
+
+      call shoc_main( &
+           turb_nadv_out_nstep, lchnk, & ! Input
+           ncol, pver, pverp, dtime, nadv_input, & ! Input
+           host_dx_input(:ncol), host_dy_input(:ncol), thv_input(:ncol,:),& ! Input
+           zt_g_input(:ncol,:pver), zi_g_input(:ncol,:pverp), pres_input(:ncol,:pver), presi_input(:ncol,:pverp), pdel_input(:ncol,:pver),& ! Input
+           wpthlp_sfc_input(:ncol), wprtp_sfc_input(:ncol), upwp_sfc_input(:ncol), vpwp_sfc_input(:ncol), & ! Input
+           wtracer_sfc(:ncol,:), edsclr_dim, wm_zt_input(:ncol,:), & ! Input
+           inv_exner_input(:ncol,:),state1%phis(:ncol), & ! Input
+           shoc_s(:ncol,:), tke_zt_input(:ncol,:), thlm_input(:ncol,:), rtm_input(:ncol,:), & ! Input/Ouput
+           um_input(:ncol,:), vm_input(:ncol,:), edsclr_in(:ncol,:,:), & ! Input/Output
+           wthv(:ncol,:),tkh_input(:ncol,:),tk_input(:ncol,:), & ! Input/Output
+           rcm_input(:ncol,:),cloud_frac_input(:ncol,:), & ! Input/Output
+           pblh(:ncol), & ! Output
+           shoc_mix_out(:ncol,:), isotropy_out(:ncol,:), & ! Output (diagnostic)
+           w_sec_out(:ncol,:), thl_sec_out(:ncol,:), qw_sec_out(:ncol,:), qwthl_sec_out(:ncol,:), & ! Output (diagnostic)
+           wthl_sec_out(:ncol,:), wqw_sec_out(:ncol,:), wtke_sec_out(:ncol,:), & ! Output (diagnostic)
+           uw_sec_out(:ncol,:), vw_sec_out(:ncol,:), w3_out(:ncol,:), & ! Output (diagnostic)
+           wqls_out(:ncol,:),brunt_out(:ncol,:),rcm2(:ncol,:)) ! Output (diagnostic)
+
+   end if  ! l_shoc_outer_loop
+
+   ! for '_input' that happen to be intent(inout), assign the output values to the variables the rest of the code is expecting.
 
    tke_zt(:ncol,:) = tke_zt_input(:ncol,:)
    thlm(:ncol,:) = thlm_input(:ncol,:)

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -89,14 +89,16 @@ module shoc_intr
   integer            :: history_budget_histfile_num
   logical            :: micro_do_icesupersat
 
-  logical            :: l_turb_standalone  ! .t. = use EAM's code infrastructure but test SHOC in
-                                           ! a single-column standalone mode
+  logical :: l_turb_standalone = .false.  ! .true. = use EAM's code infrastructure but test SHOC in
+                                          !          a single-column standalone mode
 
-  logical            :: l_shoc_outer_loop = .true.
-                                           ! .false. = experiment 1: single shoc_main call with nadv=360,
-                                           !           output written inside shoc.F90 (*_exp1.txt)
-                                           ! .true.  = experiment 2: 360 shoc_main calls with nadv=1,
-                                           !           output written from shoc_intr (*_exp2.txt)
+  logical :: l_shoc_outer_loop = .false.  ! .false. = Use a single shoc_main call with nadv calculated from
+                                          !           the host model's and SHOC's step sizes. When l_turb_standalone = .t.,
+                                          !           text output is written from the subroutine shoc_main inside shoc.F90
+                                          ! .true.  = The number of shoc_main calls is calculated from the
+                                          !           host model's and SHOC's step sizes; each call uses nadv=1.
+                                          !           When l_turb_standalone = .t.,, text output is written from
+                                          !           subroutine shoc_tend_e3sm in this module.
 
   character(len=16)  :: eddy_scheme      ! Default set in phys_control.F90
   character(len=16)  :: deep_scheme      ! Default set in phys_control.F90

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -937,7 +937,7 @@ end function shoc_implements_cnst
 
    ! Open txt file for output
 
-   if (l_turb_standalone.and.masterproc) then
+   if (single_column.and.masterproc) then
 
       ! Determine name of txt output file
 
@@ -960,13 +960,13 @@ end function shoc_implements_cnst
       write(iulog,*) 'n_shoc_main_calls = ', n_shoc_main_calls
       write(iulog,*) 'nadv              = ', nadv
 
-   end if ! l_turb_standalone.and.masterproc
+   end if ! single_column.and.masterproc
 
    ! Write statement inside shoc_main will only be executed when the simulation
    ! is run in an SCM "turb standalone" model when the nadv loop inside shoc_main
    ! is used to take multiple substeps.
 
-   l_inner_write = l_turb_standalone.and.(.not.l_shoc_outer_loop)
+   l_inner_write = single_column.and.(.not.l_shoc_outer_loop)
 
    ! ------------------------------------------------- !
    ! Actually call SHOC                                !
@@ -1000,7 +1000,7 @@ end function shoc_implements_cnst
 
       ! Write results to txt file after each shoc_main call
 
-      if (l_turb_standalone.and.l_shoc_outer_loop.and.masterproc) then
+      if (single_column.and.l_shoc_outer_loop.and.masterproc) then
            do kk = pver, 1, -1
               write(txtout_unit,fmt) i_shoc_main * nint(dtime), &!
                                      kk - 1,                    &!
@@ -1017,7 +1017,7 @@ end function shoc_implements_cnst
   end do  ! end i_shoc_main loop
   !============================
 
-  if (l_turb_standalone.and.masterproc) then
+  if (single_column.and.masterproc) then
      close(txtout_unit)
      call freeunit(txtout_unit)
   end if

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -599,7 +599,7 @@ end function shoc_implements_cnst
    integer :: n_shoc_main_calls                 ! Number of times shoc_main is called within this interface
    integer :: nadv                              ! Number of timesteps inside each call of shoc_main
 
-   integer :: n_inner_write
+   logical :: l_inner_write
    character(len=256)  :: txt_output_prefix = ''
 
    integer :: ixcldice, ixcldliq, ixnumliq, ixnumice
@@ -739,21 +739,10 @@ end function shoc_implements_cnst
   integer :: kt_cxx_read
   integer :: ierr
   integer :: unitn
-  integer :: unitn_out
+  integer :: txtout_unit
   character(len=512) :: outfname
   integer :: nstep
-  integer :: t_outer
-
-  integer :: time_output
-  integer :: ilay_output
-  real(r8) :: u_output
-  real(r8) :: v_output
-  real(r8) :: tke_output
-  real(r8) :: qv_output
-  real(r8) :: qc_output
-  real(r8) :: t_output
-  real(r8) :: p_output
-  
+  integer :: i_shoc_main
 
    ! --------------- !
    ! Pointers        !
@@ -1148,7 +1137,6 @@ end function shoc_implements_cnst
          
    end if
     
-
    if (masterproc) then
 
       if (len_trim(shoc_output_prefix) > 0) then
@@ -1156,27 +1144,26 @@ end function shoc_implements_cnst
       else
          txt_output_prefix = 'shoc_output'
       end if
+ 
       write(outfname, '(A,A,I0,A,I0,A)') trim(txt_output_prefix), '_nadv', nadv, '_x_shocm', n_shoc_main_calls, '.txt'
 
-      unitn_out = getunit()
-      open(unitn_out, file=trim(outfname), status='replace')
-      write(unitn_out,*) 'time, k (upward, starting from 0), u, v, tke, qv, qc, T, P'
-
+      txtout_unit = getunit()
+      open(txtout_unit, file=trim(outfname), status='replace')
+      write(txtout_unit,*) 'time, k (upward, starting from 0), u, v, tke, qv, qc, T, P'
    end if
 
    if (l_shoc_outer_loop) then  ! Make mulitple shoc_main calls with nadv=1. Output written here
-      n_inner_write = 0
+      l_inner_write = .false.
    else ! Make a single shoc_main call with nadv = shoc_num_steps. Output written inside shoc.F90
-      n_inner_write = turb_nadv_out_nstep
+      l_inner_write = .true.
    end if
 
    !============================
-   do t_outer = 1, n_shoc_main_calls
+   do i_shoc_main = 1, n_shoc_main_calls
 
-      !  In call to shoc_main, use _input variables in place of the default variables
       call shoc_main( &
-           unitn_out, & ! Input
-           n_inner_write, lchnk, & ! Input
+           l_inner_write, txtout_unit,     & ! Input
+           turb_nadv_out_nstep, lchnk,     & ! Input
            ncol, pver, pverp, dtime, nadv, & ! Input
            host_dx_input(:ncol), host_dy_input(:ncol), thv_input(:ncol,:),& ! Input
            zt_g_input(:ncol,:pver), zi_g_input(:ncol,:pverp), pres_input(:ncol,:pver), presi_input(:ncol,:pverp), pdel_input(:ncol,:pver),& ! Input
@@ -1198,26 +1185,25 @@ end function shoc_implements_cnst
         ! Write output variables after each shoc_main call
         if(masterproc) then
            do kk = pver, 1, -1
-              time_output = t_outer * nint(dtime)
-              ilay_output = kk - 1
-              u_output = um_input(1,kk)
-              v_output = vm_input(1,kk)
-              tke_output = tke_zt_input(1,kk)
-              qv_output = rtm_input(1,kk) - rcm_input(1,kk)
-              qc_output = rcm_input(1,kk)
-              t_output = thlm_input(1,kk) / inv_exner_input(1,kk) + latvap/cpair * rcm_input(1,kk)
-              p_output = pres_input(1,kk)
-              write(unitn_out,fmt) time_output, ilay_output, u_output, v_output, tke_output, qv_output, qc_output, t_output, p_output
+              write(txtout_unit,fmt) i_shoc_main * nint(dtime), &!
+                                     kk - 1,                &!
+                                     um_input(1,kk),        &!
+                                     vm_input(1,kk),        &!
+                                     tke_zt_input(1,kk),    &!
+                                     rtm_input(1,kk) - rcm_input(1,kk), &! qv
+                                     rcm_input(1,kk),                   &! qc
+                                     thlm_input(1,kk) / inv_exner_input(1,kk) + latvap/cpair * rcm_input(1,kk), &! temperature
+                                     pres_input(1,kk) ! pressure
            end do
         end if ! masterproc
       end if ! l_shoc_outer_loop
 
-  end do  ! end t_outer loop
+  end do  ! end i_shoc_main loop
   !============================
 
   if (masterproc) then
-     close(unitn_out)
-     call freeunit(unitn_out)
+     close(txtout_unit)
+     call freeunit(txtout_unit)
   end if
 
    ! for '_input' that happen to be intent(inout), assign the output values to the variables the rest of the code is expecting.

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -1461,10 +1461,7 @@ end function shoc_implements_cnst
 
     if (.not.masterproc) then
        call endrun('In SCM mode but calculating SHOC on multiple MPI processes?')
-    end if
-
-    if (masterproc) then
-
+    else
        !----------------------------------------------------------------
        ! Surface variables
        !----------------------------------------------------------------

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -596,6 +596,8 @@ end function shoc_implements_cnst
    integer :: n_shoc_main_calls                 ! Number of times shoc_main is called within this interface
    integer :: nadv                              ! Number of timesteps inside each call of shoc_main
 
+   integer :: n_inner_write
+
    integer :: ixcldice, ixcldliq, ixnumliq, ixnumice
    integer :: itim_old
    integer :: ncol, lchnk                       ! # of columns, and chunk identifier
@@ -1166,57 +1168,17 @@ end function shoc_implements_cnst
          write(unitn_out,*) 'time, ilay, u, v, tke, qv, qc, T, P'
       end if
 
-      do t_outer = 1, n_shoc_main_calls
-
-        call shoc_main( &
-             0, lchnk, & ! Input (turb_nadv_out_nstep=0 to suppress internal write)
-             ncol, pver, pverp, dtime, nadv, & ! Input
-             host_dx_input(:ncol), host_dy_input(:ncol), thv_input(:ncol,:),& ! Input
-             zt_g_input(:ncol,:pver), zi_g_input(:ncol,:pverp), pres_input(:ncol,:pver), presi_input(:ncol,:pverp), pdel_input(:ncol,:pver),& ! Input
-             wpthlp_sfc_input(:ncol), wprtp_sfc_input(:ncol), upwp_sfc_input(:ncol), vpwp_sfc_input(:ncol), & ! Input
-             wtracer_sfc(:ncol,:), edsclr_dim, wm_zt_input(:ncol,:), & ! Input
-             inv_exner_input(:ncol,:),state1%phis(:ncol), & ! Input
-             shoc_s(:ncol,:), tke_zt_input(:ncol,:), thlm_input(:ncol,:), rtm_input(:ncol,:), & ! Input/Ouput
-             um_input(:ncol,:), vm_input(:ncol,:), edsclr_in(:ncol,:,:), & ! Input/Output
-             wthv(:ncol,:),tkh_input(:ncol,:),tk_input(:ncol,:), & ! Input/Output
-             rcm_input(:ncol,:),cloud_frac_input(:ncol,:), & ! Input/Output
-             pblh(:ncol), & ! Output
-             shoc_mix_out(:ncol,:), isotropy_out(:ncol,:), & ! Output (diagnostic)
-             w_sec_out(:ncol,:), thl_sec_out(:ncol,:), qw_sec_out(:ncol,:), qwthl_sec_out(:ncol,:), & ! Output (diagnostic)
-             wthl_sec_out(:ncol,:), wqw_sec_out(:ncol,:), wtke_sec_out(:ncol,:), & ! Output (diagnostic)
-             uw_sec_out(:ncol,:), vw_sec_out(:ncol,:), w3_out(:ncol,:), & ! Output (diagnostic)
-             wqls_out(:ncol,:),brunt_out(:ncol,:),rcm2(:ncol,:)) ! Output (diagnostic)
-
-        ! Write output variables after each shoc_main call
-        if(masterproc) then
-           do kk = pver, 1, -1
-              time_output = t_outer * nint(dtime)
-              ilay_output = kk - 1
-              u_output = um_input(1,kk)
-              v_output = vm_input(1,kk)
-              tke_output = tke_zt_input(1,kk)
-              qv_output = rtm_input(1,kk) - rcm_input(1,kk)
-              qc_output = rcm_input(1,kk)
-              t_output = thlm_input(1,kk) / inv_exner_input(1,kk) + latvap/cpair * rcm_input(1,kk)
-              p_output = pres_input(1,kk)
-              write(unitn_out,fmt) time_output, ilay_output, u_output, v_output, tke_output, qv_output, qc_output, t_output, p_output
-           end do
-        end if
-
-      end do  ! end t_outer loop
-
-
-      if(masterproc) then
-         close(unitn_out)
-         call freeunit(unitn_out)
-      end if
-
+      n_inner_write = 0
    else
+      n_inner_write = turb_nadv_out_nstep
 
-      ! Experiment 1: single shoc_main call with nadv=360, output written inside shoc.F90
+   end if !l_shoc_outer_loop
+
+   !============================
+   do t_outer = 1, n_shoc_main_calls
 
       call shoc_main( &
-           turb_nadv_out_nstep, lchnk, & ! Input
+           n_inner_write, lchnk, & ! Input (turb_nadv_out_nstep=0 to suppress internal write)
            ncol, pver, pverp, dtime, nadv, & ! Input
            host_dx_input(:ncol), host_dy_input(:ncol), thv_input(:ncol,:),& ! Input
            zt_g_input(:ncol,:pver), zi_g_input(:ncol,:pverp), pres_input(:ncol,:pver), presi_input(:ncol,:pverp), pdel_input(:ncol,:pver),& ! Input
@@ -1234,7 +1196,33 @@ end function shoc_implements_cnst
            uw_sec_out(:ncol,:), vw_sec_out(:ncol,:), w3_out(:ncol,:), & ! Output (diagnostic)
            wqls_out(:ncol,:),brunt_out(:ncol,:),rcm2(:ncol,:)) ! Output (diagnostic)
 
-   end if  ! l_shoc_outer_loop
+      if (l_shoc_outer_loop) then
+        ! Write output variables after each shoc_main call
+        if(masterproc) then
+           do kk = pver, 1, -1
+              time_output = t_outer * nint(dtime)
+              ilay_output = kk - 1
+              u_output = um_input(1,kk)
+              v_output = vm_input(1,kk)
+              tke_output = tke_zt_input(1,kk)
+              qv_output = rtm_input(1,kk) - rcm_input(1,kk)
+              qc_output = rcm_input(1,kk)
+              t_output = thlm_input(1,kk) / inv_exner_input(1,kk) + latvap/cpair * rcm_input(1,kk)
+              p_output = pres_input(1,kk)
+              write(unitn_out,fmt) time_output, ilay_output, u_output, v_output, tke_output, qv_output, qc_output, t_output, p_output
+           end do
+        end if ! masterproc
+      end if ! l_shoc_outer_loop
+
+  end do  ! end t_outer loop
+  !============================
+
+   if (l_shoc_outer_loop) then
+      if(masterproc) then
+         close(unitn_out)
+         call freeunit(unitn_out)
+      end if
+   end if !l_shoc_outer_loop
 
    ! for '_input' that happen to be intent(inout), assign the output values to the variables the rest of the code is expecting.
 

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -24,7 +24,7 @@ module shoc_intr
   use pbl_utils,     only: calc_ustar, calc_obklen
   use perf_mod,      only: t_startf, t_stopf
   use cam_logfile,   only: iulog
-  use shoc,          only: linear_interp, largeneg
+  use shoc,          only: linear_interp, largeneg, shoc_output_prefix
   use spmd_utils,    only: masterproc
   use cam_abortutils, only: endrun
   use iop_data_mod,   only: single_column
@@ -91,11 +91,11 @@ module shoc_intr
   logical            :: l_turb_standalone  ! .t. = use EAM's code infrastructure but test SHOC in
                                            ! a single-column standalone mode
 
-  logical            :: l_shoc_outer_loop = .false.
+  logical            :: l_shoc_outer_loop = .true.
                                            ! .false. = experiment 1: single shoc_main call with nadv=360,
-                                           !           output written inside shoc.F90 (shoc_output_nadv360x1.txt)
+                                           !           output written inside shoc.F90 (*_exp1.txt)
                                            ! .true.  = experiment 2: 360 shoc_main calls with nadv=1,
-                                           !           output written from shoc_intr (shoc_output_nadv1x360.txt)
+                                           !           output written from shoc_intr (*_exp2.txt)
 
   character(len=16)  :: eddy_scheme      ! Default set in phys_control.F90
   character(len=16)  :: deep_scheme      ! Default set in phys_control.F90
@@ -240,7 +240,8 @@ end function shoc_implements_cnst
                                shoc_w2tune, shoc_length_fac, shoc_c_diag_3rd_mom, &
                                shoc_lambda_low, shoc_lambda_high, shoc_lambda_slope, &
                                shoc_lambda_thresh, shoc_Ckh, shoc_Ckm, shoc_Ckh_s, &
-                               shoc_Ckm_s
+                               shoc_Ckm_s, shoc_output_prefix, &
+                               l_shoc_outer_loop
 
     !  Read namelist to determine if SHOC history should be called
     if (masterproc) then
@@ -276,6 +277,8 @@ end function shoc_implements_cnst
       call mpibcast(shoc_Ckm,                1,   mpir8,   0, mpicom)
       call mpibcast(shoc_Ckh_s,              1,   mpir8,   0, mpicom)
       call mpibcast(shoc_Ckm_s,              1,   mpir8,   0, mpicom)
+      call mpibcast(shoc_output_prefix, len(shoc_output_prefix), mpichar, 0, mpicom)
+      call mpibcast(l_shoc_outer_loop,        1,   mpilog,  0, mpicom)
 #endif
 
   end subroutine shoc_readnl
@@ -723,6 +726,7 @@ end function shoc_implements_cnst
   integer :: ierr
   integer :: unitn
   integer :: unitn_out
+  character(len=512) :: outfname
   integer :: nstep
   integer :: t_outer
   integer :: n_outer_steps
@@ -1014,9 +1018,9 @@ end function shoc_implements_cnst
 
   if (l_shoc_outer_loop) then
      nadv_input = 1
-     n_outer_steps = 360
+     n_outer_steps = nadv
   else
-     nadv_input = 360
+     nadv_input = nadv
      n_outer_steps = 1
   end if
 
@@ -1131,9 +1135,9 @@ end function shoc_implements_cnst
    !  In call to shoc_main, use _input variables in place of the default variables
    !
    !  l_shoc_outer_loop = .false. (experiment 1):
-   !    Single shoc_main call with nadv=360. Output written inside shoc.F90 (shoc_output_nadv360x1.txt)
+   !    Single shoc_main call with nadv=360. Output written inside shoc.F90 (*_exp1.txt)
    !  l_shoc_outer_loop = .true.  (experiment 2):
-   !    360 shoc_main calls with nadv=1. Output written here (shoc_output_nadv1x360.txt)
+   !    360 shoc_main calls with nadv=1. Output written here (*_exp2.txt)
 
    if (l_shoc_outer_loop) then
 
@@ -1142,7 +1146,13 @@ end function shoc_implements_cnst
 
       if(masterproc) then
          unitn_out = getunit()
-         open(unitn_out, file='shoc_output_nadv1x360.txt', status='replace')
+         if (len_trim(shoc_output_prefix) > 0) then
+            write(outfname, '(A,A,I0,A,I0,A)') trim(shoc_output_prefix), &
+                  '_nadv', nadv_input, 'x', n_outer_steps, '_exp2.txt'
+         else
+            outfname = 'shoc_output_nadv1x360.txt'
+         end if
+         open(unitn_out, file=trim(outfname), status='replace')
          write(unitn_out,*) 'time, ilay, u, v, tke, qv, qc, T, P'
       end if
 
@@ -1170,7 +1180,7 @@ end function shoc_implements_cnst
         ! Write output variables after each shoc_main call
         if(masterproc) then
            do kk = pver, 1, -1
-              time_output = t_outer * 60
+              time_output = t_outer * nint(dtime)
               ilay_output = kk - 1
               u_output = um_input(1,kk)
               v_output = vm_input(1,kk)

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -799,7 +799,7 @@ end function shoc_implements_cnst
 
    !  determine number of timesteps SHOC core should be advanced,
    !  host time step divided by SHOC time step
-   shoc_num_steps = max(hdtime/dtime,1._r8)
+   shoc_num_steps = max(nint(hdtime/dtime), 1)
 
    !----------------------------
 

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -1426,9 +1426,6 @@ end function shoc_implements_cnst
     real(r8) :: tkh_input(pcols,pver)
     real(r8) :: cloud_frac_input(pcols,pver)
 
-    real(r8) :: host_dx_input(pcols)
-    real(r8) :: host_dy_input(pcols)
-
     character(len=72) :: junk   ! a string to hold comment lines in input text file
 
     real(r8) :: wprtp_sfc_read

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -987,7 +987,7 @@ end function shoc_implements_cnst
            turb_nadv_out_nstep, lchnk,     & ! Input
            ncol, pver, pverp, dtime, nadv, & ! Input
            host_dx_in(:ncol), host_dy_in(:ncol), thv(:ncol,:),& ! Input
-          !The line commended out below was in the orginal E3SM code. Was the use of state instead of state1 for pmid and pint a typo?
+          !The line commented out below was in the orginal E3SM code. Was the use of state instead of state1 for pmid and pint a typo?
           !zt_g(:ncol,:), zi_g(:ncol,:), state%pmid(:ncol,:pver), state%pint(:ncol,:pverp), state1%pdel(:ncol,:pver),& ! Input
            zt_g(:ncol,:), zi_g(:ncol,:),state1%pmid(:ncol,:pver),state1%pint(:ncol,:pverp), state1%pdel(:ncol,:pver),& ! Input
            wpthlp_sfc(:ncol), wprtp_sfc(:ncol), upwp_sfc(:ncol), vpwp_sfc(:ncol), & ! Input

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -675,74 +675,11 @@ end function shoc_implements_cnst
    ! For SHOC substep output
    integer :: turb_nadv_out_nstep     ! # of substeps to write out
 
-   ! For fields read in from SHOC text input files 
+   integer :: txtout_unit
+   character(len=512) :: outfname
+   integer :: i_shoc_main
 
-   real(r8) :: wprtp_sfc_input(pcols) 
-   real(r8) :: wpthlp_sfc_input(pcols) 
-   real(r8) :: upwp_sfc_input(pcols) 
-   real(r8) :: vpwp_sfc_input(pcols)
-   real(r8) :: zsurf
-
-   real(r8) :: zi_g_input(pcols,pverp)
-   real(r8) :: presi_input(pcols,pverp)
-   
-   real(r8) :: zt_g_input(pcols,pver)
-   real(r8) :: um_input(pcols,pver)
-   real(r8) :: vm_input(pcols,pver)
-   real(r8) :: wm_zt_input(pcols,pver)
-   real(r8) :: tke_zt_input(pcols,pver)
-   real(r8) :: thv_input(pcols,pver)
-   real(r8) :: thlm_input(pcols,pver)
-   real(r8) :: rtm_input(pcols,pver)
-   real(r8) :: rcm_input(pcols,pver)
-   real(r8) :: pres_input(pcols,pver)
-   real(r8) :: pdel_input(pcols,pver)
-   real(r8) :: inv_exner_input(pcols,pver)
-   real(r8) :: tk_input(pcols,pver)
-   real(r8) :: tkh_input(pcols,pver)
-   real(r8) :: cloud_frac_input(pcols,pver)
-   
-   real(r8) :: host_dx_input(pcols)
-   real(r8) :: host_dy_input(pcols)
-
-
-   character(len=72) :: junk   ! a string to hold comment lines in input text file
-  real(r8) :: wprtp_sfc_read
-  real(r8) :: wpthlp_sfc_read
-  real(r8) :: upwp_sfc_read
-  real(r8) :: vpwp_sfc_read
-  real(r8) :: pverread
-  real(r8) :: pverpread
-  real(r8) :: zi_g_read
-  real(r8) :: zt_g_read
-  real(r8) :: dz_zi_read
-  real(r8) :: um_read
-  real(r8) :: vm_read
-  real(r8) :: wm_zt_read
-  real(r8) :: tke_zt_read
-  real(r8) :: thv_read
-  real(r8) :: thlm_read
-  real(r8) :: rtm_read
-  real(r8) :: rcm_read
-  real(r8) :: presi_read
-  real(r8) :: pres_read
-  real(r8) :: pdel_read
-  real(r8) :: inv_exner_read
-  real(r8) :: tk_read
-  real(r8) :: tkh_read
-  real(r8) :: cloud_frac_read
-
-
-  integer :: kk
-  integer :: k_read
-  integer :: ki_cxx_read
-  integer :: kt_cxx_read
-  integer :: ierr
-  integer :: unitn
-  integer :: txtout_unit
-  character(len=512) :: outfname
-  integer :: nstep
-  integer :: i_shoc_main
+   integer :: kk
 
    ! --------------- !
    ! Pointers        !
@@ -974,189 +911,67 @@ end function shoc_implements_cnst
      end if
    enddo
 
-   ! ------------------------------------------------------------- !
-   ! (Placeholder for now:) Initialization for "standalone" test
-   ! ------------------------------------------------------------- !
-   if (single_column.and.l_turb_standalone) then
-      call endrun('shoc_tend_e3sm: standalone test not yet fully implemented.')
+   !-------------------------------------------
+   ! Substepping configuration (if applicable)
+   !-------------------------------------------
+   if (l_shoc_outer_loop) then
+      n_shoc_main_calls = shoc_num_steps
+      nadv = 1
+   else
+      n_shoc_main_calls = 1
+      nadv = shoc_num_steps
    end if
 
-   ! ------------------------------------------------- !
-   ! Actually call SHOC                                !
-   ! ------------------------------------------------- !
-   ! Note that this call includes nadv time steps of integration for SHOC
+   !----------------------------------------------------------------------------------
+   ! Initialization/preparation for "standalone"/"in-and-out" test (only in SCM mode)
+   !----------------------------------------------------------------------------------
+   ! Overwrite values of shoc_main's input variables using values from txt files
 
-   ! Initialize text input variables by the corresponding default values 
+   if (l_turb_standalone) then
 
-  wprtp_sfc_input = wprtp_sfc
-  wpthlp_sfc_input = wpthlp_sfc
-  upwp_sfc_input = upwp_sfc
-  vpwp_sfc_input = vpwp_sfc
-   
-  zi_g_input = zi_g
-  presi_input(:,:) = state%pint(:,:)
-
-  zt_g_input = zt_g
-  um_input = um
-  vm_input = vm
-  wm_zt_input = wm_zt
-  tke_zt_input = tke_zt
-  thv_input = thv
-  thlm_input = thlm
-  rtm_input = rtm
-  rcm_input = rcm
-  pres_input(:,:) = state%pmid(:,:)
-  pdel_input(:,:) = state1%pdel(:,:)
-  inv_exner_input = inv_exner
-  tk_input = tk
-  tkh_input = tkh
-  cloud_frac_input  = cloud_frac
-
-  !  The following are also SHOC input variables but are not present in the input text files.
-  !  So for now they will have the following values hardwired to be consistent with the in/out testing.
-
-  host_dx_input(:) = 1000._r8
-  host_dy_input(:) = 1000._r8
-
-  if (l_shoc_outer_loop) then
-     nadv = 1
-     n_shoc_main_calls = shoc_num_steps
-  else
-     nadv = shoc_num_steps
-     n_shoc_main_calls = 1
-  end if
-
-  
-   if(masterproc) then
-
-     write(iulog,*) 'Read in column surface vars initial conditions.'
-     unitn = getunit()
-     open( unitn, file='ShocInOut_IC_surface_vars.txt', status='old' )
-     read( unitn, *, iostat=ierr ) junk
-     if( ierr /= 0 ) then
-        call endrun('Error reading ShocInOut_IC_surface_vars.txt.')
-     end if
-     read( unitn, *, iostat=ierr ) junk
-     read(unitn, *)  pverread
-     write(iulog,*) 'pverread is:  ', pverread
-     pverpread = pverread + 1
-     read(unitn,*) dz_zi_read      !  dz_zi is computed in subroutine shoc_main/shoc_grid from zi_g, zt_g
-     !  So this is not directly used.
-     read(unitn,*) zsurf !  zsurf, assume zero for now and don't use
-     write(iulog,*) 'zsurf is:  ', zsurf
-     read(unitn,*) wprtp_sfc_read  ! kg/kg m/s
-     write(iulog,*) 'wprtp_sfc is:  ',wprtp_sfc_read
-     read(unitn,*) wpthlp_sfc_read  ! In SHOC this needs to be in kinematic units (K-m/s); for this input file format, it is
-     write(iulog,*) 'wpthlp_sfc is:  ',wpthlp_sfc_read
-     read(unitn,*) upwp_sfc_read
-     write(iulog,*) 'upwp_sfc is:  ',upwp_sfc_read
-     read(unitn,*) vpwp_sfc_read
-     write(iulog,*) 'vpwp_sfc is:  ',vpwp_sfc_read
-     wprtp_sfc_input(:ncol) = wprtp_sfc_read
-     wpthlp_sfc_input(:ncol) = wpthlp_sfc_read
-     upwp_sfc_input(:ncol) = upwp_sfc_read
-     vpwp_sfc_input(:ncol) = vpwp_sfc_read
-     close( unitn )
-     call freeunit( unitn )
-
-     write(iulog,*) 'Read in column zi profile initial conditions.'
-     unitn = getunit()
-     open( unitn, file='ShocInOut_IC_zi_grid.txt', status='old' )
-     read( unitn, *, iostat=ierr ) junk
-     if( ierr /= 0 ) then
-        call endrun('Error reading ShocInOut_IC_zi_grid.txt.')
-     end if
-     read( unitn, * ) junk
-     read( unitn, * ) junk
-     
-     !  This in-out exercise only makes sense if pverpread <= pverp, number of E3SM interface levels
-     !  In case pverpread > pverp, only utilize first pverp input values, ignore rest, but still read whole file.
-     
-     do k_read=1,pverpread
-      kk = pverp-k_read+1       ! Note that for SHOC k=1 is model top, but input file starts at model surface
-      read(unitn,*) ki_cxx_read, zi_g_read, presi_read   ! first column is interface index, but zero-based as in C++
-      if( (ki_cxx_read+1) .ne. k_read ) then
-        call endrun('Mismatch between interface count and k -- missing value?')
-      else if(kk.ge.1) then
-         zi_g_input(:ncol,kk) = zi_g_read
-         presi_input(:ncol,kk) = presi_read
-         write(iulog,*) kk,zi_g_read,presi_read
-      end if
-     end do
-     close( unitn )
-     call freeunit( unitn )
-
-     write(iulog,*) 'Read in column zt profile initial conditions.'
-     unitn = getunit()
-     open( unitn, file='ShocInOut_IC_zt_grid.txt', status='old' )
-     read( unitn, *, iostat=ierr ) junk
-     if( ierr /= 0 ) then
-        call endrun('Error reading ShocInOut_IC_zt_grid.txt.')
-     end if
-     read( unitn, * ) junk
-     read( unitn, * ) junk
-
-     do k_read=1,pverread
-        kk = pver-k_read+1
-     read(unitn,*) kt_cxx_read, zt_g_read, um_read, vm_read, wm_zt_read, tke_zt_read, thv_read, &
-             thlm_read, rtm_read, rcm_read, pres_read, pdel_read, inv_exner_read, tk_read, tkh_read, &
-             cloud_frac_read     ! first column is level index, but in zero-based indexing as in C++
-     if( (kt_cxx_read+1) .ne. k_read ) then
-        call endrun('Mismatch between level count and k -- missing value?')
-     else if(kk.ge.1) then
-         zt_g_input(:ncol,kk) = zt_g_read
-         um_input(:ncol,kk) = um_read
-         vm_input(:ncol,kk) = vm_read
-         wm_zt_input(:ncol,kk) = wm_zt_read
-         tke_zt_input(:ncol,kk) = tke_zt_read
-         thv_input(:ncol,kk) = thv_read
-         thlm_input(:ncol,kk) = thlm_read
-         rtm_input(:ncol,kk) = rtm_read
-         rcm_input(:ncol,kk) = rcm_read
-         pres_input(:ncol,kk) = pres_read
-         pdel_input(:ncol,kk) = pdel_read   !  Assumed to be consistent with presi(kk+1) - presi(kk)
-         inv_exner_input(:ncol,kk) = inv_exner_read  ! Assumed to be consistent with pres(kk) and interface constants
-         tk_input(:ncol,kk) = tk_read 
-         !  looks like tk, tkh are effectively intent(out), so initial values not actually used.
-         tkh_input(:ncol,kk) = tkh_read  
-         cloud_frac_input(:ncol,kk) = cloud_frac_read
-         write(iulog,*) kk, zt_g_read, um_read, vm_read, wm_zt_read, tke_zt_read, &
-              thv_read, thlm_read, rtm_read, rcm_read, pres_read, pdel_read, &
-              inv_exner_read, tk_read, tkh_read, cloud_frac_read
-      end if
-     end do
-     close( unitn )
-     call freeunit( unitn )
-     
-     write(iulog,*) 'host_dx value:  ', host_dx_in, ' to be set to ', host_dx_input
-     write(iulog,*) 'host_dy value:  ', host_dy_in, ' to be set to ', host_dy_input
-
-     write(iulog,*) 'shoc_num_steps    = ', shoc_num_steps 
-     write(iulog,*) 'n_shoc_main_calls = ', n_shoc_main_calls
-     write(iulog,*) 'nadv              = ', nadv
-         
+      call read_and_set_input_to_shoc_main( &
+             ncol, thv, zt_g, zi_g, state1%pmid, state1%pint, state1%pdel, &
+             wpthlp_sfc, wprtp_sfc, upwp_sfc, vpwp_sfc, inv_exner, tke_zt, &
+             thlm, rtm, um, vm, wm_zt, rcm, cloud_frac, tkh, tk )
    end if
-    
-   if (masterproc) then
 
-      if (len_trim(shoc_output_prefix) > 0) then
-         txt_output_prefix = trim(shoc_output_prefix)
-      else
-         txt_output_prefix = 'shoc_output'
-      end if
- 
+   ! Open txt file for output
+
+   if (l_turb_standalone.and.masterproc) then
+
+      ! Determine name of txt output file
+
+      txt_output_prefix = 'shoc_output'
+      if (len_trim(shoc_output_prefix) > 0) txt_output_prefix = trim(shoc_output_prefix)
       write(outfname, '(A,A,I0,A,I0,A)') trim(txt_output_prefix), '_nadv', nadv, '_x_shocm', n_shoc_main_calls, '.txt'
+
+      ! Open txt file and write a header
 
       txtout_unit = getunit()
       open(txtout_unit, file=trim(outfname), status='replace')
       write(txtout_unit,*) 'time, k (upward, starting from 0), u, v, tke, qv, qc, T, P'
-   end if
 
-   if (l_shoc_outer_loop) then  ! Make mulitple shoc_main calls with nadv=1. Output written here
-      l_inner_write = .false.
-   else ! Make a single shoc_main call with nadv = shoc_num_steps. Output written inside shoc.F90
-      l_inner_write = .true.
-   end if
+      ! Send info to iulog to double check
+
+     !write(iulog,*) 'host_dx value:  ', host_dx_in, ' to be set to ', host_dx_input
+     !write(iulog,*) 'host_dy value:  ', host_dy_in, ' to be set to ', host_dy_input
+
+      write(iulog,*) 'shoc_num_steps    = ', shoc_num_steps
+      write(iulog,*) 'n_shoc_main_calls = ', n_shoc_main_calls
+      write(iulog,*) 'nadv              = ', nadv
+
+   end if ! l_turb_standalone.and.masterproc
+
+   ! Write statement inside shoc_main will only be executed when the simulation
+   ! is run in an SCM "turb standalone" model when the nadv loop inside shoc_main
+   ! is used to take multiple substeps.
+
+   l_inner_write = l_turb_standalone.and.(.not.l_shoc_outer_loop)
+
+   ! ------------------------------------------------- !
+   ! Actually call SHOC                                !
+   ! ------------------------------------------------- !
+   ! Note that each call includes nadv time steps of integration for SHOC
 
    !============================
    do i_shoc_main = 1, n_shoc_main_calls
@@ -1165,15 +980,17 @@ end function shoc_implements_cnst
            l_inner_write, txtout_unit,     & ! Input
            turb_nadv_out_nstep, lchnk,     & ! Input
            ncol, pver, pverp, dtime, nadv, & ! Input
-           host_dx_input(:ncol), host_dy_input(:ncol), thv_input(:ncol,:),& ! Input
-           zt_g_input(:ncol,:pver), zi_g_input(:ncol,:pverp), pres_input(:ncol,:pver), presi_input(:ncol,:pverp), pdel_input(:ncol,:pver),& ! Input
-           wpthlp_sfc_input(:ncol), wprtp_sfc_input(:ncol), upwp_sfc_input(:ncol), vpwp_sfc_input(:ncol), & ! Input
-           wtracer_sfc(:ncol,:), edsclr_dim, wm_zt_input(:ncol,:), & ! Input
-           inv_exner_input(:ncol,:),state1%phis(:ncol), & ! Input
-           shoc_s(:ncol,:), tke_zt_input(:ncol,:), thlm_input(:ncol,:), rtm_input(:ncol,:), & ! Input/Ouput
-           um_input(:ncol,:), vm_input(:ncol,:), edsclr_in(:ncol,:,:), & ! Input/Output
-           wthv(:ncol,:),tkh_input(:ncol,:),tk_input(:ncol,:), & ! Input/Output
-           rcm_input(:ncol,:),cloud_frac_input(:ncol,:), & ! Input/Output
+           host_dx_in(:ncol), host_dy_in(:ncol), thv(:ncol,:),& ! Input
+          !The line commended out below was in the orginal E3SM code. Was the use of state instead of state1 for pmid and pint a typo?
+          !zt_g(:ncol,:), zi_g(:ncol,:), state%pmid(:ncol,:pver), state%pint(:ncol,:pverp), state1%pdel(:ncol,:pver),& ! Input
+           zt_g(:ncol,:), zi_g(:ncol,:),state1%pmid(:ncol,:pver),state1%pint(:ncol,:pverp), state1%pdel(:ncol,:pver),& ! Input
+           wpthlp_sfc(:ncol), wprtp_sfc(:ncol), upwp_sfc(:ncol), vpwp_sfc(:ncol), & ! Input
+           wtracer_sfc(:ncol,:), edsclr_dim, wm_zt(:ncol,:), & ! Input
+           inv_exner(:ncol,:),state1%phis(:ncol), & ! Input
+           shoc_s(:ncol,:), tke_zt(:ncol,:), thlm(:ncol,:), rtm(:ncol,:), & ! Input/Ouput
+           um(:ncol,:), vm(:ncol,:), edsclr_in(:ncol,:,:), & ! Input/Output
+           wthv(:ncol,:),tkh(:ncol,:),tk(:ncol,:), & ! Input/Output
+           rcm(:ncol,:),cloud_frac(:ncol,:), & ! Input/Output
            pblh(:ncol), & ! Output
            shoc_mix_out(:ncol,:), isotropy_out(:ncol,:), & ! Output (diagnostic)
            w_sec_out(:ncol,:), thl_sec_out(:ncol,:), qw_sec_out(:ncol,:), qwthl_sec_out(:ncol,:), & ! Output (diagnostic)
@@ -1181,42 +998,30 @@ end function shoc_implements_cnst
            uw_sec_out(:ncol,:), vw_sec_out(:ncol,:), w3_out(:ncol,:), & ! Output (diagnostic)
            wqls_out(:ncol,:),brunt_out(:ncol,:),rcm2(:ncol,:)) ! Output (diagnostic)
 
-      if (l_shoc_outer_loop) then
-        ! Write output variables after each shoc_main call
-        if(masterproc) then
+      ! Write results to txt file after each shoc_main call
+
+      if (l_turb_standalone.and.l_shoc_outer_loop.and.masterproc) then
            do kk = pver, 1, -1
               write(txtout_unit,fmt) i_shoc_main * nint(dtime), &!
-                                     kk - 1,                &!
-                                     um_input(1,kk),        &!
-                                     vm_input(1,kk),        &!
-                                     tke_zt_input(1,kk),    &!
-                                     rtm_input(1,kk) - rcm_input(1,kk), &! qv
-                                     rcm_input(1,kk),                   &! qc
-                                     thlm_input(1,kk) / inv_exner_input(1,kk) + latvap/cpair * rcm_input(1,kk), &! temperature
-                                     pres_input(1,kk) ! pressure
+                                     kk - 1,                    &!
+                                     um(1,kk),                  &!
+                                     vm(1,kk),                  &!
+                                     tke_zt(1,kk),              &!
+                                     rtm(1,kk) - rcm(1,kk),     &! qv
+                                     rcm(1,kk),                 &! qc
+                                     thlm(1,kk) / inv_exner(1,kk) + latvap/cpair * rcm(1,kk), &! temperature
+                                     state1%pmid(1,kk)                                         ! pressure
            end do
-        end if ! masterproc
-      end if ! l_shoc_outer_loop
+      end if
 
   end do  ! end i_shoc_main loop
   !============================
 
-  if (masterproc) then
+  if (l_turb_standalone.and.masterproc) then
      close(txtout_unit)
      call freeunit(txtout_unit)
   end if
-
-   ! for '_input' that happen to be intent(inout), assign the output values to the variables the rest of the code is expecting.
-
-   tke_zt(:ncol,:) = tke_zt_input(:ncol,:)
-   thlm(:ncol,:) = thlm_input(:ncol,:)
-   rtm(:ncol,:) = rtm_input(:ncol,:)
-   rcm(:ncol,:) = rcm_input(:ncol,:)
-   um(:ncol,:) = um_input(:ncol,:)
-   vm(:ncol,:) = vm_input(:ncol,:)
-   tkh(:ncol,:) = tkh_input(:ncol,:)
-   tk(:ncol,:) = tk_input(:ncol,:)
-   cloud_frac(:ncol,:) = cloud_frac_input(:ncol,:)
+  !---------------------------------
    
    ! Transfer back to pbuf variables
 
@@ -1571,5 +1376,216 @@ end function shoc_implements_cnst
     grid_dy = grid_dx
 
   end subroutine grid_size_planar_uniform
+
+  subroutine read_and_set_input_to_shoc_main( &
+             ncol, thv_input, &
+             zt_g_input, zi_g_input, pres_input, presi_input, pdel_input, &
+             wpthlp_sfc_input, wprtp_sfc_input, upwp_sfc_input, vpwp_sfc_input, &
+             inv_exner_input, &
+             tke_zt_input, thlm_input, rtm_input, &
+             um_input, vm_input, &
+             wm_zt_input, &
+             rcm_input, cloud_frac_input, &
+             tkh_input, tk_input &
+             )
+
+    use ppgrid, only: pver, pverp, pcols
+
+    integer, intent(in) :: ncol
+
+    ! For fields read in from SHOC text input files
+
+    real(r8) :: wprtp_sfc_input(pcols)
+    real(r8) :: wpthlp_sfc_input(pcols)
+    real(r8) :: upwp_sfc_input(pcols)
+    real(r8) :: vpwp_sfc_input(pcols)
+    real(r8) :: zsurf
+
+    real(r8) :: zi_g_input(pcols,pverp)
+    real(r8) :: presi_input(pcols,pverp)
+
+    real(r8) :: zt_g_input(pcols,pver)
+    real(r8) :: um_input(pcols,pver)
+    real(r8) :: vm_input(pcols,pver)
+    real(r8) :: wm_zt_input(pcols,pver)
+    real(r8) :: tke_zt_input(pcols,pver)
+    real(r8) :: thv_input(pcols,pver)
+    real(r8) :: thlm_input(pcols,pver)
+    real(r8) :: rtm_input(pcols,pver)
+    real(r8) :: rcm_input(pcols,pver)
+    real(r8) :: pres_input(pcols,pver)
+    real(r8) :: pdel_input(pcols,pver)
+    real(r8) :: inv_exner_input(pcols,pver)
+    real(r8) :: tk_input(pcols,pver)
+    real(r8) :: tkh_input(pcols,pver)
+    real(r8) :: cloud_frac_input(pcols,pver)
+
+    real(r8) :: host_dx_input(pcols)
+    real(r8) :: host_dy_input(pcols)
+
+    character(len=72) :: junk   ! a string to hold comment lines in input text file
+
+    real(r8) :: wprtp_sfc_read
+    real(r8) :: wpthlp_sfc_read
+    real(r8) :: upwp_sfc_read
+    real(r8) :: vpwp_sfc_read
+    real(r8) :: pverread
+    real(r8) :: pverpread
+    real(r8) :: zi_g_read
+    real(r8) :: zt_g_read
+    real(r8) :: dz_zi_read
+    real(r8) :: um_read
+    real(r8) :: vm_read
+    real(r8) :: wm_zt_read
+    real(r8) :: tke_zt_read
+    real(r8) :: thv_read
+    real(r8) :: thlm_read
+    real(r8) :: rtm_read
+    real(r8) :: rcm_read
+    real(r8) :: presi_read
+    real(r8) :: pres_read
+    real(r8) :: pdel_read
+    real(r8) :: inv_exner_read
+    real(r8) :: tk_read
+    real(r8) :: tkh_read
+    real(r8) :: cloud_frac_read
+
+    integer :: kk
+    integer :: k_read
+    integer :: ki_cxx_read
+    integer :: kt_cxx_read
+    integer :: ierr
+    integer :: unitn
+   !integer :: nstep
+
+    if (.not.masterproc) then
+       call endrun('In SCM mode but calculating SHOC on multiple MPI processes?')
+    end if
+
+    if (masterproc) then
+
+       !----------------------------------------------------------------
+       ! Surface variables
+       !----------------------------------------------------------------
+       write(iulog,*) 'Read in column surface vars initial conditions.'
+
+       unitn = getunit()
+       open( unitn, file='ShocInOut_IC_surface_vars.txt', status='old' )
+       read( unitn, *, iostat=ierr ) junk
+       if( ierr /= 0 ) then
+          call endrun('Error reading ShocInOut_IC_surface_vars.txt.')
+       end if
+       read( unitn, *, iostat=ierr ) junk
+
+       read(unitn, *)  pverread
+       write(iulog,*) 'pverread is:  ', pverread
+       pverpread = pverread + 1
+
+       read(unitn,*) dz_zi_read      !  dz_zi is computed in subroutine shoc_main/shoc_grid from zi_g, zt_g
+                                     !  So this is not directly used.
+       read(unitn,*) zsurf           !  zsurf, assume zero for now and don't use
+       write(iulog,*) 'zsurf is:  ', zsurf
+
+       read(unitn,*) wprtp_sfc_read  ! kg/kg m/s
+       write(iulog,*) 'wprtp_sfc is:  ',wprtp_sfc_read
+
+       read(unitn,*) wpthlp_sfc_read  ! In SHOC this needs to be in kinematic units (K-m/s); for this input file format, it is
+       write(iulog,*) 'wpthlp_sfc is:  ',wpthlp_sfc_read
+
+       read(unitn,*) upwp_sfc_read
+       write(iulog,*) 'upwp_sfc is:  ',upwp_sfc_read
+
+       read(unitn,*) vpwp_sfc_read
+       write(iulog,*) 'vpwp_sfc is:  ',vpwp_sfc_read
+
+       wprtp_sfc_input(:ncol) = wprtp_sfc_read
+       wpthlp_sfc_input(:ncol) = wpthlp_sfc_read
+       upwp_sfc_input(:ncol) = upwp_sfc_read
+       vpwp_sfc_input(:ncol) = vpwp_sfc_read
+
+       close( unitn )
+       call freeunit( unitn )
+
+       !----------------------------------------------------------------
+       ! Variables at layer interfaces
+       !----------------------------------------------------------------
+       write(iulog,*) 'Read in column zi profile initial conditions.'
+       unitn = getunit()
+       open( unitn, file='ShocInOut_IC_zi_grid.txt', status='old' )
+       read( unitn, *, iostat=ierr ) junk
+       if( ierr /= 0 ) then
+          call endrun('Error reading ShocInOut_IC_zi_grid.txt.')
+       end if
+       read( unitn, * ) junk
+       read( unitn, * ) junk
+
+       !  This in-out exercise only makes sense if pverpread <= pverp, number of E3SM interface levels
+       !  In case pverpread > pverp, only utilize first pverp input values, ignore rest, but still read whole file.
+
+       do k_read=1,pverpread
+        kk = pverp-k_read+1       ! Note that for SHOC k=1 is model top, but input file starts at model surface
+        read(unitn,*) ki_cxx_read, zi_g_read, presi_read   ! first column is interface index, but zero-based as in C++
+        if( (ki_cxx_read+1) .ne. k_read ) then
+          call endrun('Mismatch between interface count and k -- missing value?')
+        else if(kk.ge.1) then
+           zi_g_input(:ncol,kk) = zi_g_read
+           presi_input(:ncol,kk) = presi_read
+           write(iulog,*) kk,zi_g_read,presi_read
+        end if
+       end do
+       close( unitn )
+       call freeunit( unitn )
+
+       !----------------------------------------------------------------
+       ! Variables at layer midpoints
+       !----------------------------------------------------------------
+       write(iulog,*) 'Read in column zt profile initial conditions.'
+       unitn = getunit()
+       open( unitn, file='ShocInOut_IC_zt_grid.txt', status='old' )
+       read( unitn, *, iostat=ierr ) junk
+       if( ierr /= 0 ) then
+          call endrun('Error reading ShocInOut_IC_zt_grid.txt.')
+       end if
+       read( unitn, * ) junk
+       read( unitn, * ) junk
+
+       do k_read=1,pverread
+          kk = pver-k_read+1
+          read(unitn,*) kt_cxx_read, zt_g_read, um_read, vm_read, wm_zt_read, tke_zt_read, thv_read, &
+               thlm_read, rtm_read, rcm_read, pres_read, pdel_read, inv_exner_read, tk_read, tkh_read, &
+               cloud_frac_read     ! first column is level index, but in zero-based indexing as in C++
+
+          if( (kt_cxx_read+1) .ne. k_read ) then
+             call endrun('Mismatch between level count and k -- missing value?')
+          else if(kk.ge.1) then
+              zt_g_input(:ncol,kk) = zt_g_read
+              um_input(:ncol,kk) = um_read
+              vm_input(:ncol,kk) = vm_read
+              wm_zt_input(:ncol,kk) = wm_zt_read
+              tke_zt_input(:ncol,kk) = tke_zt_read
+              thv_input(:ncol,kk) = thv_read
+              thlm_input(:ncol,kk) = thlm_read
+              rtm_input(:ncol,kk) = rtm_read
+              rcm_input(:ncol,kk) = rcm_read
+              pres_input(:ncol,kk) = pres_read
+              pdel_input(:ncol,kk) = pdel_read   !  Assumed to be consistent with presi(kk+1) - presi(kk)
+              inv_exner_input(:ncol,kk) = inv_exner_read  ! Assumed to be consistent with pres(kk) and interface constants
+              tk_input(:ncol,kk) = tk_read
+              !  looks like tk, tkh are effectively intent(out), so initial values not actually used.
+              tkh_input(:ncol,kk) = tkh_read
+              cloud_frac_input(:ncol,kk) = cloud_frac_read
+              write(iulog,*) kk, zt_g_read, um_read, vm_read, wm_zt_read, tke_zt_read, &
+                   thv_read, thlm_read, rtm_read, rcm_read, pres_read, pdel_read, &
+                   inv_exner_read, tk_read, tkh_read, cloud_frac_read
+           end if
+
+       end do
+
+       close( unitn )
+       call freeunit( unitn )
+
+    end if ! masterproc
+
+  end subroutine read_and_set_input_to_shoc_main
 
 end module shoc_intr

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -987,7 +987,7 @@ end function shoc_implements_cnst
            turb_nadv_out_nstep, lchnk,     & ! Input
            ncol, pver, pverp, dtime, nadv, & ! Input
            host_dx_in(:ncol), host_dy_in(:ncol), thv(:ncol,:),& ! Input
-          !The line commented out below was in the orginal E3SM code. Was the use of state instead of state1 for pmid and pint a typo?
+          !The line commented out below was in the original E3SM code. Was the use of state instead of state1 for pmid and pint a typo?
           !zt_g(:ncol,:), zi_g(:ncol,:), state%pmid(:ncol,:pver), state%pint(:ncol,:pverp), state1%pdel(:ncol,:pver),& ! Input
            zt_g(:ncol,:), zi_g(:ncol,:),state1%pmid(:ncol,:pver),state1%pint(:ncol,:pverp), state1%pdel(:ncol,:pver),& ! Input
            wpthlp_sfc(:ncol), wprtp_sfc(:ncol), upwp_sfc(:ncol), vpwp_sfc(:ncol), & ! Input

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -1435,8 +1435,8 @@ end function shoc_implements_cnst
     real(r8) :: wpthlp_sfc_read
     real(r8) :: upwp_sfc_read
     real(r8) :: vpwp_sfc_read
-    real(r8) :: pverread
-    real(r8) :: pverpread
+    integer  :: pverread
+    integer  :: pverpread
     real(r8) :: zi_g_read
     real(r8) :: zt_g_read
     real(r8) :: dz_zi_read

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -949,7 +949,7 @@ end function shoc_implements_cnst
 
       txtout_unit = getunit()
       open(txtout_unit, file=trim(outfname), status='replace')
-      write(txtout_unit,*) 'time, k (upward, starting from 0), u, v, tke, qv, qc, T, P'
+      write(txtout_unit,*) 'time, k (0 = TOM, pver - 1 = sfc), u, v, tke, qv, qc, T, P'
 
       ! Send info to iulog to double check
 
@@ -1003,7 +1003,7 @@ end function shoc_implements_cnst
       if (single_column.and.l_shoc_outer_loop.and.masterproc) then
            do kk = pver, 1, -1
               write(txtout_unit,fmt) i_shoc_main * nint(dtime), &!
-                                     kk - 1,                    &!
+                                     kk - 1,                    &! 0 = TOM, pver - 1 = sfc
                                      um(1,kk),                  &!
                                      vm(1,kk),                  &!
                                      tke_zt(1,kk),              &!

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -944,9 +944,10 @@ end function shoc_implements_cnst
 
       txt_output_prefix = 'shoc_output'
       if (len_trim(shoc_output_prefix) > 0) txt_output_prefix = trim(shoc_output_prefix)
-      write(outfname, '(A,3(A,I0),A)') trim(txt_output_prefix), &
+      write(outfname, '(A,4(A,I0),A)') trim(txt_output_prefix), &
                                        '_nadv', nadv, '_x_shocm',n_shoc_main_calls, &
-                                       '_nstep',get_nstep(), '.txt'
+                                       '_nstep',get_nstep(), '_macmicsub',macmic_it,&
+                                       '.txt'
 
       ! Open txt file and write a header
 

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -24,7 +24,7 @@ module shoc_intr
   use pbl_utils,     only: calc_ustar, calc_obklen
   use perf_mod,      only: t_startf, t_stopf
   use cam_logfile,   only: iulog
-  use shoc,          only: linear_interp, largeneg, shoc_output_prefix
+  use shoc,          only: linear_interp, largeneg
   use spmd_utils,    only: masterproc
   use cam_abortutils, only: endrun
   use iop_data_mod,   only: single_column
@@ -131,6 +131,9 @@ module shoc_intr
 
   logical :: liqcf_fix = .FALSE.  ! HW for liquid cloud fraction fix
   logical :: relvar_fix = .FALSE. !PMA for relvar fix
+
+  ! Prefix for SHOC text output filenames (set via namelist shoc_output_prefix)
+  character(len=256) :: shoc_output_prefix = ''
 
   contains
 
@@ -597,6 +600,7 @@ end function shoc_implements_cnst
    integer :: nadv                              ! Number of timesteps inside each call of shoc_main
 
    integer :: n_inner_write
+   character(len=256)  :: txt_output_prefix = ''
 
    integer :: ixcldice, ixcldliq, ixnumliq, ixnumice
    integer :: itim_old
@@ -1151,34 +1155,33 @@ end function shoc_implements_cnst
    !  l_shoc_outer_loop = .true.  (experiment 2):
    !    360 shoc_main calls with nadv=1. Output written here (*_exp2.txt)
 
-   if (l_shoc_outer_loop) then
+   if(masterproc) then
+      unitn_out = getunit()
 
-      ! Experiment 2: outer loop with nadv=1, output file from shoc_intr
-      ! Suppress the write inside shoc.F90 by passing turb_nadv_out_nstep=0
-
-      if(masterproc) then
-         unitn_out = getunit()
-         if (len_trim(shoc_output_prefix) > 0) then
-            write(outfname, '(A,A,I0,A,I0,A)') trim(shoc_output_prefix), &
-                  '_nadv', nadv, 'x', n_shoc_main_calls, '_exp2.txt'
-         else
-            outfname = 'shoc_output_nadv1x360.txt'
-         end if
-         open(unitn_out, file=trim(outfname), status='replace')
-         write(unitn_out,*) 'time, ilay, u, v, tke, qv, qc, T, P'
+      if (len_trim(shoc_output_prefix) > 0) then
+         txt_output_prefix = trim(shoc_output_prefix)
+      else
+         txt_output_prefix = 'shoc_output'
       end if
+ 
+      write(outfname, '(A,A,I0,A,I0,A)') trim(txt_output_prefix), '_nadv', nadv, '_x_shocm', n_shoc_main_calls, '.txt'
 
+      open(unitn_out, file=trim(outfname), status='replace')
+      write(unitn_out,*) 'time, ilay, u, v, tke, qv, qc, T, P'
+   end if
+
+   if (l_shoc_outer_loop) then
       n_inner_write = 0
    else
       n_inner_write = turb_nadv_out_nstep
-
    end if !l_shoc_outer_loop
 
    !============================
    do t_outer = 1, n_shoc_main_calls
 
       call shoc_main( &
-           n_inner_write, lchnk, & ! Input (turb_nadv_out_nstep=0 to suppress internal write)
+           unitn_out, & ! Input
+           n_inner_write, lchnk, & ! Input
            ncol, pver, pverp, dtime, nadv, & ! Input
            host_dx_input(:ncol), host_dy_input(:ncol), thv_input(:ncol,:),& ! Input
            zt_g_input(:ncol,:pver), zi_g_input(:ncol,:pverp), pres_input(:ncol,:pver), presi_input(:ncol,:pverp), pdel_input(:ncol,:pver),& ! Input

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -539,7 +539,7 @@ end function shoc_implements_cnst
     use micro_mg_cam,   only: micro_mg_version
     use cldfrc2m,                  only: aist_vector
     use trb_mtn_stress,            only: compute_tms
-    use shoc,           only: shoc_main
+    use shoc,           only: shoc_main, fmt
     use cam_history,    only: outfld
     use iop_data_mod,   only: single_column, dp_crm
 
@@ -586,7 +586,16 @@ end function shoc_implements_cnst
    type(physics_state) :: state1                ! Local copy of state variable
    type(physics_ptend) :: ptend_loc             ! Local tendency from processes, added up to return as ptend_all
 
-   integer :: i, j, k, t, ixind, nadv
+   integer :: i, j, k, t, ixind
+   integer :: shoc_num_steps                    ! Number of SHOC substeps within a host timestep of length hdtime.
+                                                ! This number should equal (n_shoc_main_calls * nadv).
+                                                ! In the current implementation, one of the two variables,
+                                                ! n_shoc_main_calls and nadv, is set to shoc_num_steps, leaving
+                                                ! the other to be 1.
+
+   integer :: n_shoc_main_calls                 ! Number of times shoc_main is called within this interface
+   integer :: nadv                              ! Number of timesteps inside each call of shoc_main
+
    integer :: ixcldice, ixcldliq, ixnumliq, ixnumice
    integer :: itim_old
    integer :: ncol, lchnk                       ! # of columns, and chunk identifier
@@ -689,7 +698,6 @@ end function shoc_implements_cnst
    
    real(r8) :: host_dx_input(pcols)
    real(r8) :: host_dy_input(pcols)
-   integer :: nadv_input
 
 
    character(len=72) :: junk   ! a string to hold comment lines in input text file
@@ -729,7 +737,6 @@ end function shoc_implements_cnst
   character(len=512) :: outfname
   integer :: nstep
   integer :: t_outer
-  integer :: n_outer_steps
 
   integer :: time_output
   integer :: ilay_output
@@ -859,7 +866,7 @@ end function shoc_implements_cnst
 
    !  determine number of timesteps SHOC core should be advanced,
    !  host time step divided by SHOC time step
-   nadv = max(hdtime/dtime,1._r8)
+   shoc_num_steps = max(hdtime/dtime,1._r8)
 
    !----------------------------
 
@@ -1017,11 +1024,11 @@ end function shoc_implements_cnst
   host_dy_input(:) = 1000._r8
 
   if (l_shoc_outer_loop) then
-     nadv_input = 1
-     n_outer_steps = nadv
+     nadv = 1
+     n_shoc_main_calls = shoc_num_steps
   else
-     nadv_input = nadv
-     n_outer_steps = 1
+     nadv = shoc_num_steps
+     n_shoc_main_calls = 1
   end if
 
   
@@ -1128,7 +1135,10 @@ end function shoc_implements_cnst
      
      write(iulog,*) 'host_dx value:  ', host_dx_in, ' to be set to ', host_dx_input
      write(iulog,*) 'host_dy value:  ', host_dy_in, ' to be set to ', host_dy_input
-     write(iulog,*) 'nadv value:  ', nadv, ' to be set to ', nadv_input
+
+     write(iulog,*) 'shoc_num_steps    = ', shoc_num_steps 
+     write(iulog,*) 'n_shoc_main_calls = ', n_shoc_main_calls
+     write(iulog,*) 'nadv              = ', nadv
          
    end if
     
@@ -1148,7 +1158,7 @@ end function shoc_implements_cnst
          unitn_out = getunit()
          if (len_trim(shoc_output_prefix) > 0) then
             write(outfname, '(A,A,I0,A,I0,A)') trim(shoc_output_prefix), &
-                  '_nadv', nadv_input, 'x', n_outer_steps, '_exp2.txt'
+                  '_nadv', nadv, 'x', n_shoc_main_calls, '_exp2.txt'
          else
             outfname = 'shoc_output_nadv1x360.txt'
          end if
@@ -1156,11 +1166,11 @@ end function shoc_implements_cnst
          write(unitn_out,*) 'time, ilay, u, v, tke, qv, qc, T, P'
       end if
 
-      do t_outer = 1, n_outer_steps
+      do t_outer = 1, n_shoc_main_calls
 
         call shoc_main( &
              0, lchnk, & ! Input (turb_nadv_out_nstep=0 to suppress internal write)
-             ncol, pver, pverp, dtime, nadv_input, & ! Input
+             ncol, pver, pverp, dtime, nadv, & ! Input
              host_dx_input(:ncol), host_dy_input(:ncol), thv_input(:ncol,:),& ! Input
              zt_g_input(:ncol,:pver), zi_g_input(:ncol,:pverp), pres_input(:ncol,:pver), presi_input(:ncol,:pverp), pdel_input(:ncol,:pver),& ! Input
              wpthlp_sfc_input(:ncol), wprtp_sfc_input(:ncol), upwp_sfc_input(:ncol), vpwp_sfc_input(:ncol), & ! Input
@@ -1189,13 +1199,12 @@ end function shoc_implements_cnst
               qc_output = rcm_input(1,kk)
               t_output = thlm_input(1,kk) / inv_exner_input(1,kk) + latvap/cpair * rcm_input(1,kk)
               p_output = pres_input(1,kk)
-              write(unitn_out,104) time_output, ilay_output, u_output, v_output, tke_output, qv_output, qc_output, t_output, p_output
+              write(unitn_out,fmt) time_output, ilay_output, u_output, v_output, tke_output, qv_output, qc_output, t_output, p_output
            end do
         end if
 
       end do  ! end t_outer loop
 
-104   format(I5,1X,I4,5(1X,F17.14),1X,F16.12,1X,F17.10)
 
       if(masterproc) then
          close(unitn_out)
@@ -1208,7 +1217,7 @@ end function shoc_implements_cnst
 
       call shoc_main( &
            turb_nadv_out_nstep, lchnk, & ! Input
-           ncol, pver, pverp, dtime, nadv_input, & ! Input
+           ncol, pver, pverp, dtime, nadv, & ! Input
            host_dx_input(:ncol), host_dy_input(:ncol), thv_input(:ncol,:),& ! Input
            zt_g_input(:ncol,:pver), zi_g_input(:ncol,:pverp), pres_input(:ncol,:pver), presi_input(:ncol,:pverp), pdel_input(:ncol,:pver),& ! Input
            wpthlp_sfc_input(:ncol), wprtp_sfc_input(:ncol), upwp_sfc_input(:ncol), vpwp_sfc_input(:ncol), & ! Input

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -1148,37 +1148,32 @@ end function shoc_implements_cnst
          
    end if
     
-   !  In call to shoc_main, use _input variables in place of the default variables
-   !
-   !  l_shoc_outer_loop = .false. (experiment 1):
-   !    Single shoc_main call with nadv=360. Output written inside shoc.F90 (*_exp1.txt)
-   !  l_shoc_outer_loop = .true.  (experiment 2):
-   !    360 shoc_main calls with nadv=1. Output written here (*_exp2.txt)
 
-   if(masterproc) then
-      unitn_out = getunit()
+   if (masterproc) then
 
       if (len_trim(shoc_output_prefix) > 0) then
          txt_output_prefix = trim(shoc_output_prefix)
       else
          txt_output_prefix = 'shoc_output'
       end if
- 
       write(outfname, '(A,A,I0,A,I0,A)') trim(txt_output_prefix), '_nadv', nadv, '_x_shocm', n_shoc_main_calls, '.txt'
 
+      unitn_out = getunit()
       open(unitn_out, file=trim(outfname), status='replace')
-      write(unitn_out,*) 'time, ilay, u, v, tke, qv, qc, T, P'
+      write(unitn_out,*) 'time, k (upward, starting from 0), u, v, tke, qv, qc, T, P'
+
    end if
 
-   if (l_shoc_outer_loop) then
+   if (l_shoc_outer_loop) then  ! Make mulitple shoc_main calls with nadv=1. Output written here
       n_inner_write = 0
-   else
+   else ! Make a single shoc_main call with nadv = shoc_num_steps. Output written inside shoc.F90
       n_inner_write = turb_nadv_out_nstep
-   end if !l_shoc_outer_loop
+   end if
 
    !============================
    do t_outer = 1, n_shoc_main_calls
 
+      !  In call to shoc_main, use _input variables in place of the default variables
       call shoc_main( &
            unitn_out, & ! Input
            n_inner_write, lchnk, & ! Input
@@ -1220,12 +1215,10 @@ end function shoc_implements_cnst
   end do  ! end t_outer loop
   !============================
 
-   if (l_shoc_outer_loop) then
-      if(masterproc) then
-         close(unitn_out)
-         call freeunit(unitn_out)
-      end if
-   end if !l_shoc_outer_loop
+  if (masterproc) then
+     close(unitn_out)
+     call freeunit(unitn_out)
+  end if
 
    ! for '_input' that happen to be intent(inout), assign the output values to the variables the rest of the code is expecting.
 

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -28,6 +28,7 @@ module shoc_intr
   use spmd_utils,    only: masterproc
   use cam_abortutils, only: endrun
   use iop_data_mod,   only: single_column
+  use units, only:  getunit, freeunit
 
   implicit none
 
@@ -650,6 +651,84 @@ end function shoc_implements_cnst
    ! For SHOC substep output
    integer :: turb_nadv_out_nstep     ! # of substeps to write out
 
+   ! For fields read in from SHOC text input files 
+
+   real(r8) :: wprtp_sfc_input(pcols) 
+   real(r8) :: wpthlp_sfc_input(pcols) 
+   real(r8) :: upwp_sfc_input(pcols) 
+   real(r8) :: vpwp_sfc_input(pcols)
+   real(r8) :: zsurf
+
+   real(r8) :: zi_g_input(pcols,pverp)
+   real(r8) :: presi_input(pcols,pverp)
+   
+   real(r8) :: zt_g_input(pcols,pver)
+   real(r8) :: um_input(pcols,pver)
+   real(r8) :: vm_input(pcols,pver)
+   real(r8) :: wm_zt_input(pcols,pver)
+   real(r8) :: tke_zt_input(pcols,pver)
+   real(r8) :: thv_input(pcols,pver)
+   real(r8) :: thlm_input(pcols,pver)
+   real(r8) :: rtm_input(pcols,pver)
+   real(r8) :: rcm_input(pcols,pver)
+   real(r8) :: pres_input(pcols,pver)
+   real(r8) :: pdel_input(pcols,pver)
+   real(r8) :: inv_exner_input(pcols,pver)
+   real(r8) :: tk_input(pcols,pver)
+   real(r8) :: tkh_input(pcols,pver)
+   real(r8) :: cloud_frac_input(pcols,pver)
+   
+   real(r8) :: host_dx_input(pcols)
+   real(r8) :: host_dy_input(pcols)
+   integer :: nadv_input
+
+
+   character(len=72) :: junk   ! a string to hold comment lines in input text file
+  real(r8) :: wprtp_sfc_read
+  real(r8) :: wpthlp_sfc_read
+  real(r8) :: upwp_sfc_read
+  real(r8) :: vpwp_sfc_read
+  real(r8) :: pverread
+  real(r8) :: pverpread
+  real(r8) :: zi_g_read
+  real(r8) :: zt_g_read
+  real(r8) :: dz_zi_read
+  real(r8) :: um_read
+  real(r8) :: vm_read
+  real(r8) :: wm_zt_read
+  real(r8) :: tke_zt_read
+  real(r8) :: thv_read
+  real(r8) :: thlm_read
+  real(r8) :: rtm_read
+  real(r8) :: rcm_read
+  real(r8) :: presi_read
+  real(r8) :: pres_read
+  real(r8) :: pdel_read
+  real(r8) :: inv_exner_read
+  real(r8) :: tk_read
+  real(r8) :: tkh_read
+  real(r8) :: cloud_frac_read
+
+
+  integer :: kk
+  integer :: k_read
+  integer :: ki_cxx_read
+  integer :: kt_cxx_read
+  integer :: ierr
+  integer :: unitn
+  integer :: nstep
+
+  integer :: time_output
+  integer :: ilay_output
+  real(r8) :: u_output
+  real(r8) :: v_output
+  real(r8) :: tke_output
+  real(r8) :: qv_output
+  real(r8) :: qc_output
+  real(r8) :: t_output
+  real(r8) :: p_output
+  
+
    ! --------------- !
    ! Pointers        !
    ! --------------- !
@@ -892,18 +971,163 @@ end function shoc_implements_cnst
    ! ------------------------------------------------- !
    ! Note that this call includes nadv time steps of integration for SHOC
 
+   ! Initialize text input variables by the corresponding default values 
+
+  wprtp_sfc_input = wprtp_sfc
+  wpthlp_sfc_input = wpthlp_sfc
+  upwp_sfc_input = upwp_sfc
+  vpwp_sfc_input = vpwp_sfc
+   
+  zi_g_input = zi_g
+  presi_input(:,:) = state%pint(:,:)
+
+  zt_g_input = zt_g
+  um_input = um
+  vm_input = vm
+  wm_zt_input = wm_zt
+  tke_zt_input = tke_zt
+  thv_input = thv
+  thlm_input = thlm
+  rtm_input = rtm
+  rcm_input = rcm
+  pres_input(:,:) = state%pmid(:,:)
+  pdel_input(:,:) = state1%pdel(:,:)
+  inv_exner_input = inv_exner
+  tk_input = tk
+  tkh_input = tkh
+  cloud_frac_input  = cloud_frac
+
+  !  The following are also SHOC input variables but are not present in the input text files.
+  !  So for now they will have the following values hardwired to be consistent with the in/out testing.
+
+  host_dx_input(:) = 1000._r8
+  host_dy_input(:) = 1000._r8
+!  nadv_input = 100
+  nadv_input = 360 
+
+  
+   if(masterproc) then
+
+     write(iulog,*) 'Read in column surface vars initial conditions.'
+     unitn = getunit()
+     open( unitn, file='ShocInOut_IC_surface_vars.txt', status='old' )
+     read( unitn, *, iostat=ierr ) junk
+     if( ierr /= 0 ) then
+        call endrun('Error reading ShocInOut_IC_surface_vars.txt.')
+     end if
+     read( unitn, *, iostat=ierr ) junk
+     read(unitn, *)  pverread
+     write(iulog,*) 'pverread is:  ', pverread
+     pverpread = pverread + 1
+     read(unitn,*) dz_zi_read      !  dz_zi is computed in subroutine shoc_main/shoc_grid from zi_g, zt_g
+     !  So this is not directly used.
+     read(unitn,*) zsurf !  zsurf, assume zero for now and don't use
+     write(iulog,*) 'zsurf is:  ', zsurf
+     read(unitn,*) wprtp_sfc_read  ! kg/kg m/s
+     write(iulog,*) 'wprtp_sfc is:  ',wprtp_sfc_read
+     read(unitn,*) wpthlp_sfc_read  ! In SHOC this needs to be in kinematic units (K-m/s); for this input file format, it is
+     write(iulog,*) 'wpthlp_sfc is:  ',wpthlp_sfc_read
+     read(unitn,*) upwp_sfc_read
+     write(iulog,*) 'upwp_sfc is:  ',upwp_sfc_read
+     read(unitn,*) vpwp_sfc_read
+     write(iulog,*) 'vpwp_sfc is:  ',vpwp_sfc_read
+     wprtp_sfc_input(:ncol) = wprtp_sfc_read
+     wpthlp_sfc_input(:ncol) = wpthlp_sfc_read
+     upwp_sfc_input(:ncol) = upwp_sfc_read
+     vpwp_sfc_input(:ncol) = vpwp_sfc_read
+     close( unitn )
+     call freeunit( unitn )
+
+     write(iulog,*) 'Read in column zi profile initial conditions.'
+     unitn = getunit()
+     open( unitn, file='ShocInOut_IC_zi_grid.txt', status='old' )
+     read( unitn, *, iostat=ierr ) junk
+     if( ierr /= 0 ) then
+        call endrun('Error reading ShocInOut_IC_zi_grid.txt.')
+     end if
+     read( unitn, * ) junk
+     read( unitn, * ) junk
+     
+     !  This in-out exercise only makes sense if pverpread <= pverp, number of E3SM interface levels
+     !  In case pverpread > pverp, only utilize first pverp input values, ignore rest, but still read whole file.
+     
+     do k_read=1,pverpread
+      kk = pverp-k_read+1       ! Note that for SHOC k=1 is model top, but input file starts at model surface
+      read(unitn,*) ki_cxx_read, zi_g_read, presi_read   ! first column is interface index, but zero-based as in C++
+      if( (ki_cxx_read+1) .ne. k_read ) then
+        call endrun('Mismatch between interface count and k -- missing value?')
+      else if(kk.ge.1) then
+         zi_g_input(:ncol,kk) = zi_g_read
+         presi_input(:ncol,kk) = presi_read
+         write(iulog,*) kk,zi_g_read,presi_read
+      end if
+     end do
+     close( unitn )
+     call freeunit( unitn )
+
+     write(iulog,*) 'Read in column zt profile initial conditions.'
+     unitn = getunit()
+     open( unitn, file='ShocInOut_IC_zt_grid.txt', status='old' )
+     read( unitn, *, iostat=ierr ) junk
+     if( ierr /= 0 ) then
+        call endrun('Error reading ShocInOut_IC_zt_grid.txt.')
+     end if
+     read( unitn, * ) junk
+     read( unitn, * ) junk
+
+     do k_read=1,pverread
+        kk = pver-k_read+1
+     read(unitn,*) kt_cxx_read, zt_g_read, um_read, vm_read, wm_zt_read, tke_zt_read, thv_read, &
+             thlm_read, rtm_read, rcm_read, pres_read, pdel_read, inv_exner_read, tk_read, tkh_read, &
+             cloud_frac_read     ! first column is level index, but in zero-based indexing as in C++
+     if( (kt_cxx_read+1) .ne. k_read ) then
+        call endrun('Mismatch between level count and k -- missing value?')
+     else if(kk.ge.1) then
+         zt_g_input(:ncol,kk) = zt_g_read
+         um_input(:ncol,kk) = um_read
+         vm_input(:ncol,kk) = vm_read
+         wm_zt_input(:ncol,kk) = wm_zt_read
+         tke_zt_input(:ncol,kk) = tke_zt_read
+         thv_input(:ncol,kk) = thv_read
+         thlm_input(:ncol,kk) = thlm_read
+         rtm_input(:ncol,kk) = rtm_read
+         rcm_input(:ncol,kk) = rcm_read
+         pres_input(:ncol,kk) = pres_read
+         pdel_input(:ncol,kk) = pdel_read   !  Assumed to be consistent with presi(kk+1) - presi(kk)
+         inv_exner_input(:ncol,kk) = inv_exner_read  ! Assumed to be consistent with pres(kk) and interface constants
+         tk_input(:ncol,kk) = tk_read 
+         !  looks like tk, tkh are effectively intent(out), so initial values not actually used.
+         tkh_input(:ncol,kk) = tkh_read  
+         cloud_frac_input(:ncol,kk) = cloud_frac_read
+         write(iulog,*) kk, zt_g_read, um_read, vm_read, wm_zt_read, tke_zt_read, &
+              thv_read, thlm_read, rtm_read, rcm_read, pres_read, pdel_read, &
+              inv_exner_read, tk_read, tkh_read, cloud_frac_read
+      end if
+     end do
+     close( unitn )
+     call freeunit( unitn )
+     
+     write(iulog,*) 'host_dx value:  ', host_dx_in, ' to be set to ', host_dx_input
+     write(iulog,*) 'host_dy value:  ', host_dy_in, ' to be set to ', host_dy_input
+     write(iulog,*) 'nadv value:  ', nadv, ' to be set to ', nadv_input
+         
+   end if
+    
+   !  In call to shoc_main, use _input variables in place of the default variables 
+      
+     
    call shoc_main( &
         turb_nadv_out_nstep, lchnk, & ! Input
-        ncol, pver, pverp, dtime, nadv, & ! Input
-        host_dx_in(:ncol), host_dy_in(:ncol), thv(:ncol,:),& ! Input
-        zt_g(:ncol,:), zi_g(:ncol,:), state%pmid(:ncol,:pver), state%pint(:ncol,:pverp), state1%pdel(:ncol,:pver),& ! Input
-        wpthlp_sfc(:ncol), wprtp_sfc(:ncol), upwp_sfc(:ncol), vpwp_sfc(:ncol), & ! Input
-        wtracer_sfc(:ncol,:), edsclr_dim, wm_zt(:ncol,:), & ! Input
-        inv_exner(:ncol,:),state1%phis(:ncol), & ! Input
-        shoc_s(:ncol,:), tke_zt(:ncol,:), thlm(:ncol,:), rtm(:ncol,:), & ! Input/Ouput
-        um(:ncol,:), vm(:ncol,:), edsclr_in(:ncol,:,:), & ! Input/Output
-        wthv(:ncol,:),tkh(:ncol,:),tk(:ncol,:), & ! Input/Output
-        rcm(:ncol,:),cloud_frac(:ncol,:), & ! Input/Output
+        ncol, pver, pverp, dtime, nadv_input, & ! Input
+        host_dx_input(:ncol), host_dy_input(:ncol), thv_input(:ncol,:),& ! Input
+        zt_g_input(:ncol,:pver), zi_g_input(:ncol,:pverp), pres_input(:ncol,:pver), presi_input(:ncol,:pverp), pdel_input(:ncol,:pver),& ! Input
+        wpthlp_sfc_input(:ncol), wprtp_sfc_input(:ncol), upwp_sfc_input(:ncol), vpwp_sfc_input(:ncol), & ! Input
+        wtracer_sfc(:ncol,:), edsclr_dim, wm_zt_input(:ncol,:), & ! Input
+        inv_exner_input(:ncol,:),state1%phis(:ncol), & ! Input
+        shoc_s(:ncol,:), tke_zt_input(:ncol,:), thlm_input(:ncol,:), rtm_input(:ncol,:), & ! Input/Ouput
+        um_input(:ncol,:), vm_input(:ncol,:), edsclr_in(:ncol,:,:), & ! Input/Output
+        wthv(:ncol,:),tkh_input(:ncol,:),tk_input(:ncol,:), & ! Input/Output
+        rcm_input(:ncol,:),cloud_frac_input(:ncol,:), & ! Input/Output
         pblh(:ncol), & ! Output
         shoc_mix_out(:ncol,:), isotropy_out(:ncol,:), & ! Output (diagnostic)
         w_sec_out(:ncol,:), thl_sec_out(:ncol,:), qw_sec_out(:ncol,:), qwthl_sec_out(:ncol,:), & ! Output (diagnostic)
@@ -911,6 +1135,18 @@ end function shoc_implements_cnst
         uw_sec_out(:ncol,:), vw_sec_out(:ncol,:), w3_out(:ncol,:), & ! Output (diagnostic)
         wqls_out(:ncol,:),brunt_out(:ncol,:),rcm2(:ncol,:)) ! Output (diagnostic)
 
+   ! for '_input' that happend to be intent(inout), assign the output values to the variables the rest of the code is expecting.
+
+   tke_zt(:ncol,:) = tke_zt_input(:ncol,:)
+   thlm(:ncol,:) = thlm_input(:ncol,:)
+   rtm(:ncol,:) = rtm_input(:ncol,:)
+   rcm(:ncol,:) = rcm_input(:ncol,:)
+   um(:ncol,:) = um_input(:ncol,:)
+   vm(:ncol,:) = vm_input(:ncol,:)
+   tkh(:ncol,:) = tkh_input(:ncol,:)
+   tk(:ncol,:) = tk_input(:ncol,:)
+   cloud_frac(:ncol,:) = cloud_frac_input(:ncol,:)
+   
    ! Transfer back to pbuf variables
 
    do k=1,pver


### PR DESCRIPTION
Create a PR already now so that we have a place to discuss the code.

I've done a bit of refactoring of the `maint-3.0-scm-readwriteE3SMShoc` branch, mainly to

- use `l_turb_standalone` to turn on/off the "in-and-out" mode,
- keep only 1 call of `shoc_main`,
- keep largely the original call of `shoc_main` by removing intermediate variables,
- re-organize the control logic.

Let's discuss this further.