### PR TITLE
revise implementation of txt output for SCM runs with SHOC

### DIFF
--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -33,7 +33,7 @@ real(rtype), parameter, public :: largeneg = -99999999.99_rtype
 real(rtype), parameter, public :: pi = 3.14159265358979323_rtype
 
 !character(len=*), parameter, public :: fmt = '(i8,i4,20ES22.13)'
-character(len=*), parameter, public :: fmt = '(I5,1X,I4,5(1X,F17.14),1X,F16.12,1X,F17.10)'
+character(len=*), parameter, public :: fmt = '(F12.3,1X,I4,5(1X,F17.14),1X,F16.12,1X,F17.10)'
 !=========================================================
 ! Physical constants used in SHOC
 !=========================================================
@@ -582,7 +582,7 @@ subroutine shoc_main ( &
 
     if (l_txt_write.and.masterproc) then
       do kk=nlev,1,-1
-         write(txtout_unit,fmt) t*nint(dtime),                                           &! time elapsed inside this subroutine 
+         write(txtout_unit,fmt) t*dtime,                                                 &! time elapsed inside this subroutine
                                 kk-1,                                                    &! vertical layer index (0 = TOM, nlev - 1 = sfc)
                                 u_wind(1,kk), v_wind(1,kk), tke(1,kk),                   &! u, v, and tke
                                     qw(1,kk)-shoc_ql(1,kk),                              &! qv

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -32,8 +32,6 @@ logical :: use_cxx = .true.
 real(rtype), parameter, public :: largeneg = -99999999.99_rtype
 real(rtype), parameter, public :: pi = 3.14159265358979323_rtype
 
-!character(len=*), parameter, public :: fmt = '(i8,i4,20ES22.13)'
-character(len=*), parameter, public :: fmt = '(F12.3,1X,I4,5(1X,F17.14),1X,F16.12,1X,F17.10)'
 !=========================================================
 ! Physical constants used in SHOC
 !=========================================================
@@ -252,6 +250,7 @@ subroutine shoc_main ( &
 #endif
 
   use cam_history,    only: outfld
+  use turb_test,      only: txt_write_one_column
 
   implicit none
 
@@ -583,18 +582,16 @@ subroutine shoc_main ( &
     end if
 
     !---------------------------------------------
-    ! Write out fields to SHOC text output file
+    ! Write out fields to text file
 
     if (l_txt_write.and.masterproc) then
-      do kk=nlev,1,-1
-         write(txtout_unit,fmt) t*dtime,                                                 &! time elapsed inside this subroutine
-                                kk-1,                                                    &! vertical layer index (0 = TOM, nlev - 1 = sfc)
-                                u_wind(1,kk), v_wind(1,kk), tke(1,kk),                   &! u, v, and tke
-                                    qw(1,kk)-shoc_ql(1,kk),                              &! qv
-                               shoc_ql(1,kk),                                            &! qc
-                                thetal(1,kk)/inv_exner(1,kk) + lcond/cp * shoc_ql(1,kk), &! temperature
-                                  pres(1,kk)                                              ! pressure
-      end do
+         call txt_write_one_column( txtout_unit, t*dtime, nlev,         &
+                                    u_wind(1,:), v_wind(1,:), tke(1,:), &
+                                    qw(1,:)-shoc_ql(1,:),               &! qv
+                                   shoc_ql(1,:),                        &! qc
+                                    thetal(1,:)/inv_exner(1,:) + lcond/cp * shoc_ql(1,:), &! temperature
+                                    thetal(1,:), &
+                                      pres(1,:)  )! pressure
     end if
     !---------------------------------------------
 

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -416,6 +416,8 @@ subroutine shoc_main ( &
 
   integer :: kk
 
+  real(rtype) :: thv_updated(shcol,nlev)
+
 #ifdef SCREAM_CONFIG_IS_CMAKE
   integer :: clock_count1, clock_count_rate, clock_count_max, clock_count2, clock_count_diff
 #endif
@@ -496,12 +498,15 @@ subroutine shoc_main ( &
        ustar,obklen,kbfs,shoc_cldfrac,&     ! Input
        pblh)                                ! Output
 
+    thv_updated(:,:)= (thetal(:,:)+(lcond/cp)*shoc_ql(:,:)*inv_exner(:,:)) &
+                     *(1._rtype+eps*(qw(:,:) - shoc_ql(:,:))-shoc_ql(:,:))
+
     ! Update the turbulent length scale
     call shoc_length(&
        shcol,nlev,nlevi,&                ! Input
        host_dx,host_dy,&                 ! Input
        zt_grid,zi_grid,dz_zt,&           ! Input
-       tke,thv,&                         ! Input
+       tke,thv_updated,&                 ! Input
        brunt,shoc_mix)                   ! Output
 
     ! Advance the SGS TKE equation

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -250,7 +250,7 @@ subroutine shoc_main ( &
 #endif
 
   use cam_history,    only: outfld
-  use turb_test,      only: txt_write_one_column
+  use turb_test_utils,only: txt_write_one_column
 
   implicit none
 
@@ -414,6 +414,10 @@ subroutine shoc_main ( &
               wv_a(shcol),wl_a(shcol)
 
   integer :: kk
+
+  integer,parameter :: txtout_nvar_max = 20
+  real(rtype) :: txtout_array(nlev,txtout_nvar_max)
+  integer     :: iv 
 
   real(rtype) :: thv_updated(shcol,nlev)
 
@@ -585,13 +589,22 @@ subroutine shoc_main ( &
     ! Write out fields to text file
 
     if (l_txt_write.and.masterproc) then
-         call txt_write_one_column( txtout_unit, t*dtime, nlev,         &
-                                    u_wind(1,:), v_wind(1,:), tke(1,:), &
-                                    qw(1,:)-shoc_ql(1,:),               &! qv
-                                   shoc_ql(1,:),                        &! qc
-                                    thetal(1,:)/inv_exner(1,:) + lcond/cp * shoc_ql(1,:), &! temperature
-                                    thetal(1,:), &
-                                      pres(1,:)  )! pressure
+
+       ! Reminder: txtout_varnames(1:txtout_nvar) = (/"time","k","zm","pmid","u","v","tke","qv","qc","cldf","T","qt","thlm"/)
+       iv = 0
+       iv = iv + 1; txtout_array(:,iv) = zt_grid(1,:) ! height above sfc
+       iv = iv + 1; txtout_array(:,iv) =    pres(1,:) ! pressure
+       iv = iv + 1; txtout_array(:,iv) =  u_wind(1,:)
+       iv = iv + 1; txtout_array(:,iv) =  v_wind(1,:)
+       iv = iv + 1; txtout_array(:,iv) =     tke(1,:)
+       iv = iv + 1; txtout_array(:,iv) =      qw(1,:) - shoc_ql(1,:) ! qv 
+       iv = iv + 1; txtout_array(:,iv) = shoc_ql(1,:)
+       iv = iv + 1; txtout_array(:,iv) = shoc_cldfrac(1,:)
+       iv = iv + 1; txtout_array(:,iv) =  thetal(1,:)/inv_exner(1,:) + lcond/cp * shoc_ql(1,:)  ! temperature
+       iv = iv + 1; txtout_array(:,iv) =      qw(1,:)                ! qt
+       iv = iv + 1; txtout_array(:,iv) =  thetal(1,:)
+
+       call txt_write_one_column( txtout_unit, t*dtime, nlev, iv, txtout_array )
     end if
     !---------------------------------------------
 

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -573,12 +573,14 @@ end function shoc_implements_cnst
     use micro_mg_cam,   only: micro_mg_version
     use cldfrc2m,                  only: aist_vector
     use trb_mtn_stress,            only: compute_tms
-    use shoc,           only: shoc_main, fmt
+    use shoc,           only: shoc_main
     use cam_history,    only: outfld
     use iop_data_mod,   only: single_column, dp_crm
 
     use conditional_diag,      only: cnd_diag_t
     use conditional_diag_main, only: cnd_diag_checkpoint
+
+    use turb_test, only: set_switches_for_txt_output, txt_file_open_and_init, txt_write_one_column
 
     implicit none
 
@@ -636,7 +638,6 @@ end function shoc_implements_cnst
    integer :: nadv                              ! Number of timesteps inside each call of shoc_main
 
    logical :: l_inner_write
-   character(len=256)  :: txt_output_prefix = ''
 
    integer :: ixcldice, ixcldliq, ixnumliq, ixnumice
    integer :: itim_old
@@ -715,7 +716,6 @@ end function shoc_implements_cnst
    logical :: l_open_txt_output
 
    integer, save :: txtout_unit
-   character(len=512) :: outfname
    integer :: i_shoc_main
 
    integer :: kk
@@ -1005,6 +1005,7 @@ end function shoc_implements_cnst
              thlm, rtm, um, vm, wm_zt, rcm, cloud_frac, tkh, tk )
 
       wthv(:ncol,:) = 0.0_r8
+     wm_zt(:ncol,:) = 0.0_r8  ! BJG -- hardwiring wm_zt = 0.0 to be consistent with no_omega test.
 
    end if ! l_turb_standalone
 
@@ -1013,74 +1014,15 @@ end function shoc_implements_cnst
   !wprtp_sfc(:ncol) = 0.0_r8  ! BJG test to hardwire surface moisture flux to zero
    upwp_sfc(:ncol) = -0.068547301186844697_r8  ! BJG test to hardwire surface u flux to input text file value
    vpwp_sfc(:ncol) = 0.053858593789663699_r8  ! BJG test to hardwire surface v flux to input text file value
-   wm_zt(:ncol,:) = 0.0_r8  ! BJG -- hardwiring wm_zt = 0.0 to be consistent with no_omega test.
 
-   !-------------------------------------------------------------------------------------
-   ! Set switches for opening and closing txt file(s) when it's time.
-   !-------------------------------------------------------------------------------------
-   ! Txt output is handled only by the master MPI process in an SCM run.
+   !--------------------------------------------------------------------------------------------
+   ! Prepare for txt output. Only relevant when this is the master MPI process in an SCM run.
+   !--------------------------------------------------------------------------------------------
+   call set_switches_for_txt_output( single_column, masterproc, l_turb_standalone, &! in
+                                     l_open_txt_output, l_clse_txt_output          )! out
 
-   if (single_column.and.masterproc) then
-
-      ! If the SCM is configured to be turb standalone, in principle
-      ! we only need a single call of this subroutine (shoc_tend_eam)
-      ! and a single txt file from the call, despite the fact
-      ! that a 1-timestep EAM run will call this subroutine 3 times
-      ! because of model initialization and finalization.
-
-      if (l_turb_standalone) then
-
-         l_open_txt_output = .true.   ! open a new file and write header info everytime we get here.
-         l_clse_txt_output = .true.   ! close the file and free i/o unit in this subroutine after shoc is called.
-
-      ! If the SCM is not confugured to be turb standalone,
-      ! open a new file and write header info at the very beginning of the simulation,
-      ! i.e., in the very first EAM time step during the first macmic substep;
-      ! keep the file open during the entire simulation.
-      else
-
-         l_open_txt_output = (is_first_step()) .and. (macmic_it.eq.1)
-         l_clse_txt_output = .false.
-
-      end if
-
-   else
-   ! In global simulations, we won't have txt output; set both switches to .false.
-   ! In case an SCM simulation contains multiple grid columns for some reason,
-   ! do not produce txt output from MPI processes other than the master.
-
-      l_open_txt_output = .false.
-      l_clse_txt_output = .false.
-
-   end if
-
-   !--------------------------------------------
    ! Open txt output file if it's time to do so
-   !--------------------------------------------
-   if (l_open_txt_output) then
-
-      ! Determine name of txt output file
-
-      txt_output_prefix = 'shoc_output'                                                  ! set a default
-      if (len_trim(shoc_output_prefix) > 0) txt_output_prefix = trim(shoc_output_prefix) ! overwrite by nml input
-      write(outfname, '(A,4(A,I0),A)') trim(txt_output_prefix), &
-                                       '_nstep',get_nstep(), '_macmicsub',macmic_it,&
-                                       '.txt'
-
-      ! Open txt file and write a header
-
-       txtout_unit = getunit()
-       open(txtout_unit, file=trim(outfname), status='replace')
-       write(txtout_unit,*) 'time, k (0 = TOM, pver - 1 = sfc), u, v, tke, qv, qc, T, P'
-
-   end if ! l_open_txt_output
-
-
-   call cnd_diag_checkpoint(diag, 'SHOCc'//char_macmic_it, state1, pbuf, cam_in, cam_out)
-   ! ------------------------------------------------- !
-   ! Actually call SHOC                                !
-   ! ------------------------------------------------- !
-   ! Note that each call includes nadv time steps of integration for SHOC
+   if (l_open_txt_output) call txt_file_open_and_init( trim(shoc_output_prefix), get_nstep(), macmic_it, txtout_unit )
 
    ! Write statement inside shoc_main will only be executed when the simulation
    ! is run in an SCM "turb standalone" model when the nadv loop inside shoc_main
@@ -1088,7 +1030,13 @@ end function shoc_implements_cnst
 
    l_inner_write = l_turb_standalone .and. (.not.l_shoc_outer_loop)
 
-   !============================
+   ! ================================================= !
+   ! Actually call SHOC                                !
+   ! ================================================= !
+   ! Note that each call includes nadv time steps of integration for SHOC
+
+   call cnd_diag_checkpoint(diag, 'SHOCc'//char_macmic_it, state1, pbuf, cam_in, cam_out)
+
    do i_shoc_main = 1, n_shoc_main_calls
 
       call shoc_main( &
@@ -1113,7 +1061,7 @@ end function shoc_implements_cnst
            uw_sec_out(:ncol,:), vw_sec_out(:ncol,:), w3_out(:ncol,:), & ! Output (diagnostic)
            wqls_out(:ncol,:),brunt_out(:ncol,:),rcm2(:ncol,:)) ! Output (diagnostic)
 
-      ! Write results to txt file after each shoc_main call if conditions are met.
+      ! Write results to txt file after each shoc_main call if conditions are met. -------------------
 
       if (single_column .and. l_shoc_outer_loop .and. masterproc) then
 
@@ -1124,18 +1072,14 @@ end function shoc_implements_cnst
                        +  dtime * i_shoc_main
          end if
 
-         do kk = pver, 1, -1
-            write(txtout_unit,fmt) modeltime,                 &!
-                                   kk - 1,                    &! 0 = TOM, pver - 1 = sfc
-                                   um(1,kk),                  &!
-                                   vm(1,kk),                  &!
-                                   tke_zt(1,kk),              &!
-                                   rtm(1,kk) - rcm(1,kk),     &! qv
-                                   rcm(1,kk),                 &! qc
-                                   thlm(1,kk) / inv_exner(1,kk) + latvap/cpair * rcm(1,kk), &! temperature
-                                   state1%pmid(1,kk)                                         ! pressure
-         end do
-      end if
+         call txt_write_one_column( txtout_unit, modeltime, pver,  &
+                                    um(1,:), vm(1,:), tke_zt(1,:), &
+                                   rtm(1,:) - rcm(1,:),            &
+                                   rcm(1,:),                       &
+                                  thlm(1,:) / inv_exner(1,:) + latvap/cpair * rcm(1,:), &! temperature
+                                  thlm(1,:),                       &
+                                  state1%pmid(1,:)                 )
+      end if !-----------
 
   end do  ! end i_shoc_main loop
   !============================
@@ -1143,9 +1087,6 @@ end function shoc_implements_cnst
   if (l_clse_txt_output) then
      close(txtout_unit)
      call freeunit(txtout_unit)
- !else if(masterproc.and.(.not.(l_turb_standalone)).and.(modeltime.ge.endtime)) then
- !   close(txtout_unit)
- !   call freeunit(txtout_unit)
   end if
 
   !---------------------------------

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -154,7 +154,7 @@ module shoc_intr
   logical :: relvar_fix = .FALSE. !PMA for relvar fix
 
   ! Prefix for SHOC text output filenames (set via namelist shoc_output_prefix)
-  character(len=256) :: shoc_output_prefix = ''
+  character(len=256) :: shoc_output_prefix = 'shoc_output'
 
 
 
@@ -1019,10 +1019,11 @@ end function shoc_implements_cnst
    ! Prepare for txt output. Only relevant when this is the master MPI process in an SCM run.
    !--------------------------------------------------------------------------------------------
    call set_switches_for_txt_output( single_column, masterproc, l_turb_standalone, &! in
+                                     is_first_step(), macmic_it,                   &! in
                                      l_open_txt_output, l_clse_txt_output          )! out
 
    ! Open txt output file if it's time to do so
-   if (l_open_txt_output) call txt_file_open_and_init( trim(shoc_output_prefix), get_nstep(), macmic_it, txtout_unit )
+   if (l_open_txt_output) call txt_file_open_and_init( shoc_output_prefix, get_nstep(), macmic_it, txtout_unit )
 
    ! Write statement inside shoc_main will only be executed when the simulation
    ! is run in an SCM "turb standalone" model when the nadv loop inside shoc_main

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -593,8 +593,8 @@ end function shoc_implements_cnst
    real(r8),            intent(in)    :: dlf(pcols,pver)          ! Detraining cld H20 from deep convection [kg/ks/s]
    real(r8),            intent(in)    :: cmfmc(pcols,pverp)       ! convective mass flux--m sub c           [kg/m2/s]
    real(r8),            intent(in)    :: sgh30(pcols)             ! std deviation of orography              [m]
-   integer,             intent(in)    :: cld_macmic_num_steps     ! number of mac-mic iterations
-   integer,             intent(in)    :: macmic_it                ! number of mac-mic iterations
+   integer,             intent(in)    :: cld_macmic_num_steps     ! total number of mac-mic iterations
+   integer,             intent(in)    :: macmic_it                ! current mac-mic iteration
    ! ---------------------- !
    ! Input-Output Auguments !
    ! ---------------------- !
@@ -711,6 +711,9 @@ end function shoc_implements_cnst
    ! For SHOC substep output
    integer :: turb_nadv_out_nstep     ! # of substeps to write out
 
+   logical :: l_clse_txt_output
+   logical :: l_open_txt_output
+
    integer, save :: txtout_unit
    character(len=512) :: outfname
    integer :: i_shoc_main
@@ -718,8 +721,8 @@ end function shoc_implements_cnst
    integer :: kk
 
    integer :: hdtime_int
-   integer :: modeltime
    integer :: endtime
+   real(r8) :: modeltime
 
    character(len=2) :: char_macmic_it
 
@@ -981,8 +984,16 @@ end function shoc_implements_cnst
       nadv = shoc_num_steps
    end if
 
+   ! Send info to iulog to double check
+   if (masterproc.and.is_first_step()) then
+      write(iulog,*) 'shoc_num_steps    = ', shoc_num_steps
+      write(iulog,*) 'n_shoc_main_calls = ', n_shoc_main_calls
+      write(iulog,*) 'nadv              = ', nadv
+   end if
+
    !----------------------------------------------------------------------------------
-   ! Initialization/preparation for "standalone"/"in-and-out" test (only in SCM mode)
+   ! Set ICs for "standalone"/"in-and-out" test. Note that l_trub_standalone can
+   ! only be .true. in SCM mode.
    !----------------------------------------------------------------------------------
    if (l_turb_standalone) then
 
@@ -995,85 +1006,88 @@ end function shoc_implements_cnst
 
       wthv(:ncol,:) = 0.0_r8
 
-      if (masterproc) then
+   end if ! l_turb_standalone
 
-         ! Determine name of txt output file
+   !!!!! need an if-statement here
+  !wpthlp_sfc(:ncol) = 0.0_r8  ! BJG test to hardwire surface thl flux to zero
+  !wprtp_sfc(:ncol) = 0.0_r8  ! BJG test to hardwire surface moisture flux to zero
+   upwp_sfc(:ncol) = -0.068547301186844697_r8  ! BJG test to hardwire surface u flux to input text file value
+   vpwp_sfc(:ncol) = 0.053858593789663699_r8  ! BJG test to hardwire surface v flux to input text file value
 
-         txt_output_prefix = 'shoc_output'
-         if (len_trim(shoc_output_prefix) > 0) txt_output_prefix = trim(shoc_output_prefix)
-         write(outfname, '(A,4(A,I0),A)') trim(txt_output_prefix), &
-                                          '_nadv', nadv, '_x_shocm',n_shoc_main_calls, &
-                                          '_nstep',get_nstep(), '_macmicsub',macmic_it,&
-                                          '.txt'
+  !wm_zt(:ncol,:) = 0.0_r8  ! BJG -- hardwiring wm_zt = 0.0 to be consistent with no_omega test.
 
-         ! Open txt file and write a header
+   !-------------------------------------------------------------------------------------
+   ! Set switches for opening and closing txt file(s) when it's time.
+   !-------------------------------------------------------------------------------------
+   ! Txt output is handled only by the master MPI process in an SCM run.
 
-         txtout_unit = getunit()
-         open(txtout_unit, file=trim(outfname), status='replace')
-         write(txtout_unit,*) 'time, k (0 = TOM, pver - 1 = sfc), u, v, tke, qv, qc, T, P'
+   if (single_column.and.masterproc) then
 
-         ! Send info to iulog to double check
+      ! If the SCM is configured to be turb standalone, in principle
+      ! we only need a single call of this subroutine (shoc_tend_eam)
+      ! and a single txt file from the call, despite the fact
+      ! that a 1-timestep EAM run will call this subroutine 3 times
+      ! because of model initialization and finalization.
 
-         write(iulog,*) 'shoc_num_steps    = ', shoc_num_steps
-         write(iulog,*) 'n_shoc_main_calls = ', n_shoc_main_calls
-         write(iulog,*) 'nadv              = ', nadv
+      if (l_turb_standalone) then
 
-      end if  ! masterproc
+         l_open_txt_output = .true.   ! open a new file and write header info everytime we get here.
+         l_clse_txt_output = .true.   ! close the file and free i/o unit in this subroutine after shoc is called.
 
+      ! If the SCM is not confugured to be turb standalone,
+      ! open a new file and write header info at the very beginning of the simulation,
+      ! i.e., in the very first EAM time step during the first macmic substep;
+      ! keep the file open during the entire simulation.
+      else
+
+         l_open_txt_output = (is_first_step()) .and. (macmic_it.eq.1)
+         l_clse_txt_output = .false.
+
+      end if
 
    else
+   ! In global simulations, we won't have txt output; set both switches to .false.
+   ! In case an SCM simulation contains multiple grid columns for some reason,
+   ! do not produce txt output from MPI processes other than the master.
 
-        ! BJG Not doing "standalone"/"in-and-out" mode, but still want same format text output each timestep.
+      l_open_txt_output = .false.
+      l_clse_txt_output = .false.
 
-      if (masterproc) then
+   end if
 
-        ! Determine name of txt output file
+   !--------------------------------------------
+   ! Open txt output file if it's time to do so
+   !--------------------------------------------
+   if (l_open_txt_output) then
 
-         txt_output_prefix = 'shoc_output'
-         hdtime_int = nint(hdtime)
-          if (len_trim(shoc_output_prefix) > 0) txt_output_prefix = trim(shoc_output_prefix)
-          write(outfname, '(A,2(A,I0),A)') trim(txt_output_prefix), &
-                                           '_hdtime', hdtime_int, &
-                                           '_macmicsub',macmic_it,&
-                                           '.txt'
-          ! Open txt file and write a header at initial timestep
+      ! Determine name of txt output file
 
-          if (get_nstep().eq.0) then
+      txt_output_prefix = 'shoc_output'                                                  ! set a default
+      if (len_trim(shoc_output_prefix) > 0) txt_output_prefix = trim(shoc_output_prefix) ! overwrite by nml input
+      write(outfname, '(A,4(A,I0),A)') trim(txt_output_prefix), &
+                                       '_nstep',get_nstep(), '_macmicsub',macmic_it,&
+                                       '.txt'
 
-             txtout_unit = getunit()
-             open(txtout_unit, file=trim(outfname), status='replace')
-             write(txtout_unit,*) 'time, k (0 = TOM, pver - 1 = sfc), u, v, tke, qv, qc, T, P'
+      ! Open txt file and write a header
 
-          ! Send info to iulog to double check
+       txtout_unit = getunit()
+       open(txtout_unit, file=trim(outfname), status='replace')
+       write(txtout_unit,*) 'time, k (0 = TOM, pver - 1 = sfc), u, v, tke, qv, qc, T, P'
 
-             write(iulog,*) 'hdtime              = ', hdtime
-
-          end if ! get_nstep = 0
-
-       end if  ! masterproc
+   end if ! l_open_txt_output
 
 
-   end if ! l_turb_standalone
+   call cnd_diag_checkpoint(diag, 'SHOCc'//char_macmic_it, state1, pbuf, cam_in, cam_out)
+   ! ------------------------------------------------- !
+   ! Actually call SHOC                                !
+   ! ------------------------------------------------- !
+   ! Note that each call includes nadv time steps of integration for SHOC
 
    ! Write statement inside shoc_main will only be executed when the simulation
    ! is run in an SCM "turb standalone" model when the nadv loop inside shoc_main
    ! is used to take multiple substeps.
 
    l_inner_write = l_turb_standalone .and. (.not.l_shoc_outer_loop)
-
-   wpthlp_sfc(:ncol) = 0.0_r8  ! BJG test to hardwire surface thl flux to zero
-   wprtp_sfc(:ncol) = 0.0_r8  ! BJG test to hardwire surface moisture flux to zero
-   upwp_sfc(:ncol) = -0.068547301186844697_r8  ! BJG test to hardwire surface u flux to input text file value
-   vpwp_sfc(:ncol) = 0.053858593789663699_r8  ! BJG test to hardwire surface v flux to input text file value
-
-   wm_zt(:ncol,:) = 0.0_r8  ! BJG -- hardwiring wm_zt = 0.0 to be consistent with no_omega test.
-
-   
-   call cnd_diag_checkpoint(diag, 'SHOCc'//char_macmic_it, state1, pbuf, cam_in, cam_out)
-   ! ------------------------------------------------- !
-   ! Actually call SHOC                                !
-   ! ------------------------------------------------- !
-   ! Note that each call includes nadv time steps of integration for SHOC
 
    !============================
    do i_shoc_main = 1, n_shoc_main_calls
@@ -1102,54 +1116,45 @@ end function shoc_implements_cnst
 
       ! Write results to txt file after each shoc_main call if conditions are met.
 
-      if (l_turb_standalone .and. l_shoc_outer_loop .and. masterproc) then
-           do kk = pver, 1, -1
-              write(txtout_unit,fmt) i_shoc_main * nint(dtime), &!
-                                     kk - 1,                    &! 0 = TOM, pver - 1 = sfc
-                                     um(1,kk),                  &!
-                                     vm(1,kk),                  &!
-                                     tke_zt(1,kk),              &!
-                                     rtm(1,kk) - rcm(1,kk),     &! qv
-                                     rcm(1,kk),                 &! qc
-                                     thlm(1,kk) / inv_exner(1,kk) + latvap/cpair * rcm(1,kk), &! temperature
-                                     state1%pmid(1,kk)                                         ! pressure
-           end do
+      if (single_column .and. l_shoc_outer_loop .and. masterproc) then
+
+         if (l_turb_standalone) then
+            modeltime = i_shoc_main * dtime
+         else
+            modeltime =  hdtime * ( get_nstep() * cld_macmic_num_steps + macmic_it - 1 ) &
+                       +  dtime * i_shoc_main
+         end if
+
+         do kk = pver, 1, -1
+            write(txtout_unit,fmt) modeltime,                 &!
+                                   kk - 1,                    &! 0 = TOM, pver - 1 = sfc
+                                   um(1,kk),                  &!
+                                   vm(1,kk),                  &!
+                                   tke_zt(1,kk),              &!
+                                   rtm(1,kk) - rcm(1,kk),     &! qv
+                                   rcm(1,kk),                 &! qc
+                                   thlm(1,kk) / inv_exner(1,kk) + latvap/cpair * rcm(1,kk), &! temperature
+                                   state1%pmid(1,kk)                                         ! pressure
+         end do
       end if
 
   end do  ! end i_shoc_main loop
   !============================
 
+  if (l_clse_txt_output) then
+     close(txtout_unit)
+     call freeunit(txtout_unit)
+ !else if(masterproc.and.(.not.(l_turb_standalone)).and.(modeltime.ge.endtime)) then
+ !   close(txtout_unit)
+ !   call freeunit(txtout_unit)
+  end if
+
+  !---------------------------------
+  ! Transfer back to pbuf variables
+
    thlm_in_pbuf = thlm
     rtm_in_pbuf = rtm
-
-       ! Write results to txt file after each shoc_main call in other cases
-
-  if (.not.(l_turb_standalone) .and. masterproc) then
-       modeltime = get_nstep() * nint(hdtime)
-       do kk = pver, 1, -1
-          write(txtout_unit,fmt) modeltime, &!
-                                 kk - 1,                    &! 0 = TOM, pver - 1 = sfc
-                                 um(1,kk),                  &!
-                                 vm(1,kk),                  &!
-                                 tke_zt(1,kk),              &!
-                                 rtm(1,kk) - rcm(1,kk),     &! qv
-                                 rcm(1,kk),                 &! qc
-                                 thlm(1,kk) / inv_exner(1,kk) + latvap/cpair * rcm(1,kk), &! temperature
-                                 state1%pmid(1,kk)                                         ! pressure
-       end do
-  end if
- 
-
-  if (l_turb_standalone.and.masterproc) then
-     close(txtout_unit)
-     call freeunit(txtout_unit)
-  else if(masterproc.and.(.not.(l_turb_standalone)).and.(modeltime.ge.endtime)) then  
-     close(txtout_unit)
-     call freeunit(txtout_unit)
-  end if
-  !---------------------------------
    
-   ! Transfer back to pbuf variables
 
    do k=1,pver
      do i=1,ncol

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -580,7 +580,7 @@ end function shoc_implements_cnst
     use conditional_diag,      only: cnd_diag_t
     use conditional_diag_main, only: cnd_diag_checkpoint
 
-    use turb_test, only: set_switches_for_txt_output, txt_file_open_and_init, txt_write_one_column
+    use turb_test_utils, only: set_switches_for_txt_output, txt_file_open_and_init, txt_write_one_column
 
     implicit none
 
@@ -718,7 +718,12 @@ end function shoc_implements_cnst
    integer, save :: txtout_unit
    integer :: i_shoc_main
 
-   integer :: kk
+   integer,parameter :: txtout_nvar_max = 20
+   character(len=22) :: txtout_varnames(txtout_nvar_max) = ""
+   integer           :: txtout_nvar                      ! actual number of variables to be written to txt file(s)
+
+   real(r8) :: txtout_array(pver,txtout_nvar_max)
+   integer  :: iv 
 
    integer :: hdtime_int
    integer :: endtime
@@ -1023,7 +1028,12 @@ end function shoc_implements_cnst
                                      l_open_txt_output, l_clse_txt_output          )! out
 
    ! Open txt output file if it's time to do so
-   if (l_open_txt_output) call txt_file_open_and_init( shoc_output_prefix, get_nstep(), macmic_it, txtout_unit )
+
+   txtout_nvar = 13
+   txtout_varnames(1:txtout_nvar) = (/"time","k","zm","pmid","u","v","tke","qv","qc","cldf","T","qt","thlm"/)
+   if (l_open_txt_output) call txt_file_open_and_init( shoc_output_prefix, get_nstep(), macmic_it,  &! in
+                                                       txtout_nvar, txtout_varnames(1:txtout_nvar), &! in
+                                                       txtout_unit                                  )! out
 
    ! Write statement inside shoc_main will only be executed when the simulation
    ! is run in an SCM "turb standalone" model when the nadv loop inside shoc_main
@@ -1073,13 +1083,24 @@ end function shoc_implements_cnst
                        +  dtime * i_shoc_main
          end if
 
-         call txt_write_one_column( txtout_unit, modeltime, pver,  &
-                                    um(1,:), vm(1,:), tke_zt(1,:), &
-                                   rtm(1,:) - rcm(1,:),            &
-                                   rcm(1,:),                       &
-                                  thlm(1,:) / inv_exner(1,:) + latvap/cpair * rcm(1,:), &! temperature
-                                  thlm(1,:),                       &
-                                  state1%pmid(1,:)                 )
+         ! Reminder: txtout_varnames(1:txtout_nvar) = (/"time","k","zm","pmid","u","v","tke","qv","qc","cldf","T","qt","thlm"/)
+
+         iv = 0
+         iv = iv + 1; txtout_array(:,iv) =  zt_g(1,:)
+         iv = iv + 1; txtout_array(:,iv) =  state1%pmid(1,:)
+         iv = iv + 1; txtout_array(:,iv) =  um(1,:)
+         iv = iv + 1; txtout_array(:,iv) =  vm(1,:)
+         iv = iv + 1; txtout_array(:,iv) =  tke_zt(1,:)
+         iv = iv + 1; txtout_array(:,iv) =  rtm(1,:) - rcm(1,:) ! qv
+         iv = iv + 1; txtout_array(:,iv) =  rcm(1,:)
+         iv = iv + 1; txtout_array(:,iv) =  cloud_frac(1,:)
+         iv = iv + 1; txtout_array(:,iv) =  thlm(1,:) / inv_exner(1,:) + latvap/cpair * rcm(1,:)  ! temperature
+         iv = iv + 1; txtout_array(:,iv) =   rtm(1,:)
+         iv = iv + 1; txtout_array(:,iv) =  thlm(1,:)
+
+         if (iv.ne.(txtout_nvar-2)) call endrun('call txt_write_one_column: iv and txtout_nvar are inconsistent')
+         call txt_write_one_column( txtout_unit, modeltime, pver, iv, txtout_array )
+
       end if !-----------
 
   end do  ! end i_shoc_main loop

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -1013,8 +1013,7 @@ end function shoc_implements_cnst
   !wprtp_sfc(:ncol) = 0.0_r8  ! BJG test to hardwire surface moisture flux to zero
    upwp_sfc(:ncol) = -0.068547301186844697_r8  ! BJG test to hardwire surface u flux to input text file value
    vpwp_sfc(:ncol) = 0.053858593789663699_r8  ! BJG test to hardwire surface v flux to input text file value
-
-  !wm_zt(:ncol,:) = 0.0_r8  ! BJG -- hardwiring wm_zt = 0.0 to be consistent with no_omega test.
+   wm_zt(:ncol,:) = 0.0_r8  ! BJG -- hardwiring wm_zt = 0.0 to be consistent with no_omega test.
 
    !-------------------------------------------------------------------------------------
    ! Set switches for opening and closing txt file(s) when it's time.

--- a/components/eam/src/physics/cam/turb_test.F90
+++ b/components/eam/src/physics/cam/turb_test.F90
@@ -2,18 +2,21 @@ module turb_test
 
   use shr_kind_mod,  only: r8=>shr_kind_r8
 
+  implicit none
+
   public
 
 contains
 
 subroutine set_switches_for_txt_output( single_column, masterproc, l_turb_standalone, &! in
+                                        l_first_step, macmic_it,                      &! in
                                         l_open_txt_output, l_clse_txt_output          )! out
-
-   use time_manager, only: is_first_step
 
    logical, intent(in) :: single_column
    logical, intent(in) :: masterproc
    logical, intent(in) :: l_turb_standalone
+   logical, intent(in) :: l_first_step
+   integer, intent(in) :: macmic_it
 
    logical, intent(out) :: l_open_txt_output
    logical, intent(out) :: l_clse_txt_output
@@ -39,7 +42,7 @@ subroutine set_switches_for_txt_output( single_column, masterproc, l_turb_standa
       ! keep the file open during the entire simulation.
       else
 
-         l_open_txt_output = (is_first_step()) .and. (macmic_it.eq.1)
+         l_open_txt_output = l_first_step .and. (macmic_it.eq.1)
          l_clse_txt_output = .false.
 
       end if

--- a/components/eam/src/physics/cam/turb_test.F90
+++ b/components/eam/src/physics/cam/turb_test.F90
@@ -1,0 +1,123 @@
+module turb_test
+
+  use shr_kind_mod,  only: r8=>shr_kind_r8
+
+  public
+
+contains
+
+subroutine set_switches_for_txt_output( single_column, masterproc, l_turb_standalone, &! in
+                                        l_open_txt_output, l_clse_txt_output          )! out
+
+   use time_manager, only: is_first_step
+
+   logical, intent(in) :: single_column
+   logical, intent(in) :: masterproc
+   logical, intent(in) :: l_turb_standalone
+
+   logical, intent(out) :: l_open_txt_output
+   logical, intent(out) :: l_clse_txt_output
+
+   ! Txt output is handled only by the master MPI process in an SCM run.
+
+   if (single_column.and.masterproc) then
+
+      ! If the SCM is configured to be turb standalone, in principle
+      ! we only need a single call of this subroutine (shoc_tend_eam)
+      ! and a single txt file from the call, despite the fact
+      ! that a 1-timestep EAM run will call this subroutine 3 times
+      ! because of model initialization and finalization.
+
+      if (l_turb_standalone) then
+
+         l_open_txt_output = .true.   ! open a new file and write header info everytime we get here.
+         l_clse_txt_output = .true.   ! close the file and free i/o unit in this subroutine after shoc is called.
+
+      ! If the SCM is not confugured to be turb standalone,
+      ! open a new file and write header info at the very beginning of the simulation,
+      ! i.e., in the very first EAM time step during the first macmic substep;
+      ! keep the file open during the entire simulation.
+      else
+
+         l_open_txt_output = (is_first_step()) .and. (macmic_it.eq.1)
+         l_clse_txt_output = .false.
+
+      end if
+
+   else
+   ! In global simulations, we won't have txt output; set both switches to .false.
+   ! In case an SCM simulation contains multiple grid columns for some reason,
+   ! do not produce txt output from MPI processes other than the master.
+
+      l_open_txt_output = .false.
+      l_clse_txt_output = .false.
+
+   end if
+
+end subroutine set_switches_for_txt_output
+
+
+subroutine txt_file_open_and_init( prefix_in, nstep_current, macmic_it, &! in
+                                   txtout_unit                          )! out
+
+   use units, only: getunit
+
+   character(len=*),intent(in) :: prefix_in
+   integer,intent(in)  :: nstep_current
+   integer,intent(in)  :: macmic_it
+   integer,intent(out) :: txtout_unit
+
+   character(len=256)  :: txt_output_prefix = ''
+   character(len=256)  :: outfname
+
+   ! Determine name of txt output file
+
+   txt_output_prefix = 'turb_output'                                ! set a default
+   if (len_trim(prefix_in) > 0) txt_output_prefix = trim(prefix_in) ! overwrite by nml input
+   write(outfname, '(A,4(A,I0),A)') trim(txt_output_prefix), &
+                                    '_nstep',nstep_current, '_macmicsub',macmic_it,'.txt'
+
+   ! Open txt file and write a header
+
+   txtout_unit = getunit()
+   open(txtout_unit, file=trim(outfname), status='replace')
+   write(txtout_unit,*) 'time, k (0 = TOM, pver - 1 = sfc), u, v, tke, qv, qc, thlm, T, P'
+ 
+end subroutine txt_file_open_and_init
+
+
+subroutine txt_write_one_column(txtout_unit,modeltime,nlev, &
+                                um, vm, tke, qv, qc, temp, thlm, pmid)
+
+  integer, intent(in) :: txtout_unit
+  real(r8),intent(in) :: modeltime
+  integer, intent(in) :: nlev
+
+  real(r8),intent(in) ::   um(:)
+  real(r8),intent(in) ::   vm(:)
+  real(r8),intent(in) ::  tke(:)
+  real(r8),intent(in) ::   qv(:)
+  real(r8),intent(in) ::   qc(:)
+  real(r8),intent(in) :: temp(:)
+  real(r8),intent(in) :: thlm(:)
+  real(r8),intent(in) :: pmid(:)
+
+  integer :: kk
+  character(len=*),parameter :: fmt = '(F8.2,I5,10E23.14)'
+
+  do kk = nlev, 1, -1
+     write(txtout_unit,fmt) modeltime,&!
+                            kk - 1,   &! 0 = TOM, pver - 1 = sfc
+                            um(kk),   &!
+                            vm(kk),   &!
+                            tke(kk),  &!
+                             qv(kk),  &!
+                             qc(kk),  &!
+                           thlm(kk),  &!
+                           temp(kk),  &!
+                           pmid(kk)    ! pressure
+  end do
+
+end subroutine txt_write_one_column
+
+end module turb_test

--- a/components/eam/src/physics/cam/turb_test_utils.F90
+++ b/components/eam/src/physics/cam/turb_test_utils.F90
@@ -1,4 +1,4 @@
-module turb_test
+module turb_test_utils
 
   use shr_kind_mod,  only: r8=>shr_kind_r8
 
@@ -60,67 +60,58 @@ subroutine set_switches_for_txt_output( single_column, masterproc, l_turb_standa
 end subroutine set_switches_for_txt_output
 
 
-subroutine txt_file_open_and_init( prefix_in, nstep_current, macmic_it, &! in
-                                   txtout_unit                          )! out
+subroutine txt_file_open_and_init( prefix_in, nstep_current, macmic_it, nvarnames, varnames, &! in
+                                   txtout_unit                                               )! out
 
    use units, only: getunit
 
    character(len=*),intent(in) :: prefix_in
-   integer,intent(in)  :: nstep_current
-   integer,intent(in)  :: macmic_it
-   integer,intent(out) :: txtout_unit
+   integer,intent(in)          :: nstep_current
+   integer,intent(in)          :: macmic_it
+   integer,intent(in)          :: nvarnames
+   character(len=*),intent(in) :: varnames(nvarnames)
+   integer,intent(out)         :: txtout_unit
+
+   ! Local variables
 
    character(len=256)  :: txt_output_prefix = ''
    character(len=256)  :: outfname
+   integer :: iv
 
    ! Determine name of txt output file
 
    txt_output_prefix = 'turb_output'                                ! set a default
    if (len_trim(prefix_in) > 0) txt_output_prefix = trim(prefix_in) ! overwrite by nml input
-   write(outfname, '(A,4(A,I0),A)') trim(txt_output_prefix), &
+   write(outfname, '(A,2(A,I0),A)') trim(txt_output_prefix), &
                                     '_nstep',nstep_current, '_macmicsub',macmic_it,'.txt'
 
    ! Open txt file and write a header
 
    txtout_unit = getunit()
    open(txtout_unit, file=trim(outfname), status='replace')
-   write(txtout_unit,*) 'time, k (0 = TOM, pver - 1 = sfc), u, v, tke, qv, qc, thlm, T, P'
+   write(txtout_unit,'(A10,A5,20A23)') (varnames(iv), iv=1,nvarnames) 
  
 end subroutine txt_file_open_and_init
 
 
-subroutine txt_write_one_column(txtout_unit,modeltime,nlev, &
-                                um, vm, tke, qv, qc, temp, thlm, pmid)
+subroutine txt_write_one_column(txtout_unit,modeltime,nlev,nv,merged_array )
 
   integer, intent(in) :: txtout_unit
   real(r8),intent(in) :: modeltime
   integer, intent(in) :: nlev
+  integer, intent(in) :: nv    ! # of physical quantities, not counting time and level index
 
-  real(r8),intent(in) ::   um(:)
-  real(r8),intent(in) ::   vm(:)
-  real(r8),intent(in) ::  tke(:)
-  real(r8),intent(in) ::   qv(:)
-  real(r8),intent(in) ::   qc(:)
-  real(r8),intent(in) :: temp(:)
-  real(r8),intent(in) :: thlm(:)
-  real(r8),intent(in) :: pmid(:)
+  real(r8),intent(in) :: merged_array(:,:)
 
-  integer :: kk
-  character(len=*),parameter :: fmt = '(F8.2,I5,10E23.14)'
+  integer :: kk, iv
+  character(len=*),parameter :: fmt = '(F8.2,I5,20E23.14)'
 
   do kk = nlev, 1, -1
      write(txtout_unit,fmt) modeltime,&!
                             kk - 1,   &! 0 = TOM, pver - 1 = sfc
-                            um(kk),   &!
-                            vm(kk),   &!
-                            tke(kk),  &!
-                             qv(kk),  &!
-                             qc(kk),  &!
-                           thlm(kk),  &!
-                           temp(kk),  &!
-                           pmid(kk)    ! pressure
+                            (merged_array(kk,iv),iv=1,nv)
   end do
 
 end subroutine txt_write_one_column
 
-end module turb_test
+end module turb_test_utils


### PR DESCRIPTION
- consolidate similar code blocks;
- revise control logic so that txt output works also when
  - cld_macmic_num_steps > 1
  - l_shoc_outer_loop = .t. in "normal" SCM runs (l_turb_standalone = .f.)
- revise calculation of `modeltime` for txt output to account for cld_macmic_num_steps > 1
- write out time as floating point numbers instead of integers