### PR TITLE
SHOC diagnostics (LSCALE, SHOC_MIX terms) + thv refresh in the nadv loop

### DIFF
--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -457,6 +457,16 @@ subroutine shoc_main ( &
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
   if (use_cxx) then
+    ! The new diagnostics (Larson length scale and shoc_mix term
+    ! decomposition) are intent(out) but are NOT computed on this C++ path
+    ! (see NOTE below). Zero them so the caller never receives undefined
+    ! values that could be written to history/txt output.
+    lscale_shoc      = 0._rtype
+    lscale_up_shoc   = 0._rtype
+    lscale_down_shoc = 0._rtype
+    shoc_mix_surf    = 0._rtype
+    shoc_mix_linf    = 0._rtype
+    shoc_mix_strat   = 0._rtype
     call shoc_main_f(shcol, nlev, nlevi, dtime, nadv, npbl,& ! Input
                      host_dx, host_dy,thv, &                 ! Input
                      zt_grid,zi_grid,pres,presi,pdel,&       ! Input
@@ -557,15 +567,23 @@ subroutine shoc_main ( &
     ! (so this diagnostic and SHOC's own mixing length see the same input
     ! state, making them directly comparable).
     !
-    ! Reads SHOC's evolved state; does NOT modify it. Output goes to
-    ! history (LSCALE_SHOC, LSCALE_UP_SHOC, LSCALE_DOWN_SHOC) via the host
-    ! interface, and to the in-and-out txt file from inside the substep
-    ! loop below when l_txt_write=.true.
-    call shoc_compute_lscale(                                 &
-         shcol, nlev, nlevi,                                  &  ! Input
-         thetal, qw, tke, shoc_thv,                           &  ! Input
-         pres, inv_exner, zt_grid, zi_grid,                   &  ! Input
-         lscale_shoc, lscale_up_shoc, lscale_down_shoc)          ! Output
+    ! Reads SHOC's evolved state; does NOT modify it -- this is a pure
+    ! diagnostic that nothing in the SHOC solver consumes. It has two output
+    ! paths: history (LSCALE_SHOC, LSCALE_UP_SHOC, LSCALE_DOWN_SHOC) via the
+    ! host interface, and the in-and-out txt file written from inside this
+    ! substep loop below when l_txt_write=.true.
+    !
+    ! For history only the final-substep value survives (the array is
+    ! overwritten each t and outfld'd after the loop), so we only need to run
+    ! the (expensive) algorithm on the last substep -- UNLESS we are writing
+    ! the per-substep txt dump, which needs it every t.
+    if (l_txt_write .or. t == nadv) then
+       call shoc_compute_lscale(                              &
+            shcol, nlev, nlevi,                               &  ! Input
+            thetal, qw, tke, shoc_thv,                        &  ! Input
+            pres, inv_exner, zt_grid, zi_grid,                &  ! Input
+            lscale_shoc, lscale_up_shoc, lscale_down_shoc)       ! Output
+    end if
 
     ! Update the turbulent length scale.  Note: shoc_thv (refreshed this
     ! nadv iteration) is used instead of the intent(in) thv so that
@@ -579,13 +597,19 @@ subroutine shoc_main ( &
 
     ! Diagnostic decomposition of shoc_mix into its three component length
     ! scales (surface/wall, asymptotic l_inf, stable stratification), in [m].
-    ! Uses the same brunt shoc_length just produced; reuses
-    ! compute_l_inf_shoc_length for l_inf. Output to history only
+    ! Uses the same brunt shoc_length just produced. Output to history only
     ! (SHOC_MIX_SURF/LINF/STRAT); does not feed back into the solution.
-    call compute_shoc_mix_terms(&
-       shcol,nlev,&                                    ! Input
-       tke,brunt,zt_grid,dz_zt,&                       ! Input
-       shoc_mix_surf,shoc_mix_linf,shoc_mix_strat)     ! Output
+    !
+    ! Pure diagnostic, history-only (not in the txt dump), so only the
+    ! final-substep value survives the loop -- compute it on the last
+    ! substep only. This also collapses the l_inf recompute below (see the
+    ! subroutine header) to once per shoc_main call.
+    if (t == nadv) then
+       call compute_shoc_mix_terms(&
+          shcol,nlev,&                                    ! Input
+          tke,brunt,zt_grid,dz_zt,&                       ! Input
+          shoc_mix_surf,shoc_mix_linf,shoc_mix_strat)     ! Output
+    end if
 
     ! Advance the SGS TKE equation
     call shoc_tke(&
@@ -5026,10 +5050,23 @@ subroutine compute_shoc_mix_terms(&
   ! Each component length L_k = (2.8284/length_fac)*sqrt(1/A_k), so (pre-clip)
   !   1/shoc_mix^2 = 1/L_surf^2 + 1/L_linf^2 + 1/L_strat^2.
   !
-  ! These three term expressions MIRROR compute_shoc_mix_shoc_length; if that
-  ! formula is ever retuned, update both. Diagnostic only: does not modify
-  ! shoc_mix. l_inf is obtained by reusing compute_l_inf_shoc_length (no
-  ! duplication of the asymptotic-length-scale calculation).
+  ! These three term expressions MIRROR compute_shoc_mix_shoc_length. That
+  ! formula is hardcoded in source (its constants are NOT namelist-tunable):
+  ! the literals 2.8284, 0.01, and tscale=400, plus the module parameters
+  ! length_fac, maxlen, and vk. If any of those constants is changed, or the
+  ! formula's structure is changed (a term added/removed, the functional form,
+  ! the maxlen clipping, or the harmonic-sum-of-squares combination), the same
+  ! edit MUST be made here -- otherwise this decomposition silently drifts out
+  ! of sync and no longer sums to the real shoc_mix. Diagnostic only: does not
+  ! modify shoc_mix.
+  !
+  ! l_inf is recomputed here via compute_l_inf_shoc_length rather than reused
+  ! from shoc_length (which keeps it as a local and discards it). Threading
+  ! l_inf out of shoc_length would alter that standard SHOC routine's
+  ! signature -- shared with the SCREAM/C++ port -- so we deliberately accept
+  ! one extra call here. The cost is negligible: compute_l_inf_shoc_length is
+  ! a cheap pair of vertical sums, and the caller only invokes this routine on
+  ! the final nadv substep (history-only), so it runs once per shoc_main call.
   !=========================================================
 
   implicit none
@@ -5037,7 +5074,8 @@ subroutine compute_shoc_mix_terms(&
   integer, intent(in) :: nlev, shcol
   ! turbulent kinetic energy [m^2/s^2]
   real(rtype), intent(in) :: tke(shcol,nlev)
-  ! brunt vaisala frequency [s-1]
+  ! brunt vaisala frequency squared, N^2 [s-2]
+  ! (note: 'brunt' holds N^2, not N; negative where unstable)
   real(rtype), intent(in) :: brunt(shcol,nlev)
   ! heights on thermo (midpoint) grid [m]
   real(rtype), intent(in) :: zt_grid(shcol,nlev)

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -33,7 +33,10 @@ real(rtype), parameter, public :: largeneg = -99999999.99_rtype
 real(rtype), parameter, public :: pi = 3.14159265358979323_rtype
 
 !character(len=*), parameter, public :: fmt = '(i8,i4,20ES22.13)'
-character(len=*), parameter, public :: fmt = '(I5,1X,I4,5(1X,F17.14),1X,F16.12,1X,F17.10)'
+! 7 reals for state (u, v, tke, qv, qc, T, P) plus 3 reals for the diagnostic
+! Larson length scale (lscale, lscale_up, lscale_down). Width F12.4 fits the
+! Lscale_max = 6250 m cap with margin.
+character(len=*), parameter, public :: fmt = '(I5,1X,I4,5(1X,F17.14),1X,F16.12,1X,F17.10,3(1X,F12.4))'
 !=========================================================
 ! Physical constants used in SHOC
 !=========================================================
@@ -241,7 +244,8 @@ subroutine shoc_main ( &
      w_sec, thl_sec, qw_sec, qwthl_sec,&  ! Output (diagnostic)
      wthl_sec, wqw_sec, wtke_sec,&        ! Output (diagnostic)
      uw_sec, vw_sec, w3,&                 ! Output (diagnostic)
-     wqls_sec, brunt, shoc_ql2 &          ! Output (diagnostic)
+     wqls_sec, brunt, shoc_ql2, &         ! Output (diagnostic)
+     lscale_shoc, lscale_up_shoc, lscale_down_shoc & ! Output (diagnostic, NEW)
 #ifdef SCREAM_CONFIG_IS_CMAKE
      , elapsed_s &
 #endif
@@ -252,6 +256,7 @@ subroutine shoc_main ( &
 #endif
 
   use cam_history,    only: outfld
+  use shoc_lscale_mod, only: shoc_compute_lscale
 
   implicit none
 
@@ -374,6 +379,14 @@ subroutine shoc_main ( &
   real(rtype), intent(out) :: brunt(shcol,nlev)
   ! return to isotropic timescale [s]
   real(rtype), intent(out) :: isotropy(shcol,nlev)
+  ! Larson nonlocal moist length scale (diagnostic, SHOC-internal port of
+  ! the standalone calculate_lscale used at physpkg.F90:tphysbc). Computed
+  ! once per nadv substep right after pblintd and right before shoc_length,
+  ! analogous to where CLUBB calls compute_mixing_length inside
+  ! advance_clubb_core.
+  real(rtype), intent(out) :: lscale_shoc     (shcol, nlev)  ! [m]
+  real(rtype), intent(out) :: lscale_up_shoc  (shcol, nlev)  ! [m]
+  real(rtype), intent(out) :: lscale_down_shoc(shcol, nlev)  ! [m]
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
   real(rtype), optional, intent(out) :: elapsed_s ! duration of main loop in seconds
@@ -400,6 +413,17 @@ subroutine shoc_main ( &
   real(rtype) :: dz_zt(shcol,nlev)
   ! Grid difference centereted on interface grid [m]
   real(rtype) :: dz_zi(shcol,nlevi)
+
+  ! Virtual potential temperature recomputed each nadv iteration from the
+  ! current substep state (thetal, qw, shoc_ql, inv_exner). The intent(in)
+  ! `thv` argument is computed once per shoc_tend_e3sm call (in shoc_intr,
+  ! before the i_shoc_main loop) and then held constant. Inside the nadv
+  ! loop here, thetal/qw/tke evolve via update_prognostics_implicit but
+  ! `thv` does not, so it goes stale. This local thv_now is used in place
+  ! of `thv` for shoc_length (-> compute_brunt_shoc_length) and the
+  ! diagnostic shoc_compute_lscale, so they see the same substep state as
+  ! the rest of the SHOC closure.
+  real(rtype) :: thv_now(shcol,nlev)
 
   ! Surface friction velocity [m/s]
   real(rtype) :: ustar(shcol)
@@ -438,6 +462,22 @@ subroutine shoc_main ( &
                      wthl_sec, wqw_sec, wtke_sec,&           ! Output (diagnostic)
                      uw_sec, vw_sec, w3,&                    ! Output (diagnostic)
                      wqls_sec, brunt, shoc_ql2)              ! Output (diagnostic)
+
+    ! Diagnostic Larson nonlocal moist length scale. Computed in F90 even
+    ! when the SHOC core runs as C++, so the LSCALE_SHOC history field is
+    ! always populated. Uses end-of-kernel state (the C++ kernel has just
+    ! evolved thetal, qw, tke, etc.). Recompute thv_now here so it is
+    ! consistent with the other end-of-kernel arrays passed in.
+    ! Formula matches pblintd_init_pot (shoc.F90:4475-4477): theta =
+    ! thetal + (Lv/cp)*qc, thv = theta * (1 + eps*qv - qc), with
+    ! qv = qw - shoc_ql.
+    thv_now(:,:) = ( thetal(:,:) + (lcond/cp) * shoc_ql(:,:) ) &
+                   * ( 1.0_rtype + eps * ( qw(:,:) - shoc_ql(:,:) ) - shoc_ql(:,:) )
+    call shoc_compute_lscale(                                 &
+         shcol, nlev, nlevi,                                  &  ! Input
+         thetal, qw, tke, thv_now,                            &  ! Input
+         pres, inv_exner, zt_grid, zi_grid,                   &  ! Input
+         lscale_shoc, lscale_up_shoc, lscale_down_shoc)          ! Output
      return
   endif
 #endif
@@ -456,6 +496,18 @@ subroutine shoc_main ( &
      se_b,ke_b,wv_b,wl_b)                   ! Input/Output
 
   do t=1,nadv
+
+    ! Refresh virtual potential temperature from the current substep state.
+    ! The intent(in) `thv` argument is set once per shoc_tend_e3sm call
+    ! (in shoc_intr.F90, before the i_shoc_main loop) and then held
+    ! constant, while thetal/qw/shoc_ql evolve via update_prognostics_implicit
+    ! within this loop. Using a stale `thv` would bias compute_brunt_shoc_length
+    ! (and therefore shoc_mix above the cloud-top inversion in DYCOMS), and
+    ! would also bias the diagnostic shoc_compute_lscale at all levels.
+    ! Formula matches pblintd_init_pot (shoc.F90:4475-4477): theta = thetal
+    ! + (Lv/cp)*qc, thv = theta * (1 + eps*qv - qc), with qv = qw - shoc_ql.
+    thv_now(:,:) = ( thetal(:,:) + (lcond/cp) * shoc_ql(:,:) ) &
+                   * ( 1.0_rtype + eps * ( qw(:,:) - shoc_ql(:,:) ) - shoc_ql(:,:) )
 
     ! Check TKE to make sure values lie within acceptable
     !  bounds after host model performs horizontal advection
@@ -496,12 +548,32 @@ subroutine shoc_main ( &
        ustar,obklen,kbfs,shoc_cldfrac,&     ! Input
        pblh)                                ! Output
 
-    ! Update the turbulent length scale
+    ! Diagnostic Larson nonlocal moist length scale (SHOC-side parallel of
+    ! H. Xiao's standalone calculate_lscale used by tphysbc).
+    !
+    ! Placed after pblintd (which sets the boundary-layer state used by
+    ! the surface-layer taper inside the algorithm) and before shoc_length
+    ! (so this diagnostic and SHOC's own mixing length see the same input
+    ! state, making them directly comparable).
+    !
+    ! Reads SHOC's evolved state; does NOT modify it. Output goes to
+    ! history (LSCALE_SHOC, LSCALE_UP_SHOC, LSCALE_DOWN_SHOC) via the host
+    ! interface, and to the in-and-out txt file from inside the substep
+    ! loop below when l_txt_write=.true.
+    call shoc_compute_lscale(                                 &
+         shcol, nlev, nlevi,                                  &  ! Input
+         thetal, qw, tke, thv_now,                            &  ! Input
+         pres, inv_exner, zt_grid, zi_grid,                   &  ! Input
+         lscale_shoc, lscale_up_shoc, lscale_down_shoc)          ! Output
+
+    ! Update the turbulent length scale.  Note: thv_now (refreshed at top
+    ! of this nadv iteration) is used instead of the intent(in) thv so
+    ! that compute_brunt_shoc_length sees the current substep state.
     call shoc_length(&
        shcol,nlev,nlevi,&                ! Input
        host_dx,host_dy,&                 ! Input
        zt_grid,zi_grid,dz_zt,&           ! Input
-       tke,thv,&                         ! Input
+       tke,thv_now,&                     ! Input
        brunt,shoc_mix)                   ! Output
 
     ! Advance the SGS TKE equation
@@ -582,13 +654,16 @@ subroutine shoc_main ( &
 
     if (l_txt_write.and.masterproc) then
       do kk=nlev,1,-1
-         write(txtout_unit,fmt) t*nint(dtime),                                           &! time elapsed inside this subroutine 
+         write(txtout_unit,fmt) t*nint(dtime),                                           &! time elapsed inside this subroutine
                                 kk-1,                                                    &! vertical layer index (0 = TOM, nlev - 1 = sfc)
                                 u_wind(1,kk), v_wind(1,kk), tke(1,kk),                   &! u, v, and tke
                                     qw(1,kk)-shoc_ql(1,kk),                              &! qv
                                shoc_ql(1,kk),                                            &! qc
                                 thetal(1,kk)/inv_exner(1,kk) + lcond/cp * shoc_ql(1,kk), &! temperature
-                                  pres(1,kk)                                              ! pressure
+                                  pres(1,kk),                                            &! pressure
+                            lscale_shoc(1,kk),                                           &! Larson Lscale [m]
+                         lscale_up_shoc(1,kk),                                           &! Larson Lscale (upward) [m]
+                       lscale_down_shoc(1,kk)                                             ! Larson Lscale (downward) [m]
       end do
     end if
     !---------------------------------------------

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -245,7 +245,8 @@ subroutine shoc_main ( &
      wthl_sec, wqw_sec, wtke_sec,&        ! Output (diagnostic)
      uw_sec, vw_sec, w3,&                 ! Output (diagnostic)
      wqls_sec, brunt, shoc_ql2, &         ! Output (diagnostic)
-     lscale_shoc, lscale_up_shoc, lscale_down_shoc & ! Output (diagnostic, NEW)
+     lscale_shoc, lscale_up_shoc, lscale_down_shoc, & ! Output (diagnostic, NEW)
+     shoc_mix_surf, shoc_mix_linf, shoc_mix_strat & ! Output (diagnostic, NEW: shoc_mix term decomposition)
 #ifdef SCREAM_CONFIG_IS_CMAKE
      , elapsed_s &
 #endif
@@ -387,6 +388,14 @@ subroutine shoc_main ( &
   real(rtype), intent(out) :: lscale_shoc     (shcol, nlev)  ! [m]
   real(rtype), intent(out) :: lscale_up_shoc  (shcol, nlev)  ! [m]
   real(rtype), intent(out) :: lscale_down_shoc(shcol, nlev)  ! [m]
+  ! Decomposition of SHOC's own mixing length shoc_mix into its three component
+  ! length scales (diagnostic). All in [m] so they are directly comparable to
+  ! SHOC_MIX. shoc_mix combines them in quadrature:
+  !   1/shoc_mix^2 = 1/shoc_mix_surf^2 + 1/shoc_mix_linf^2 + 1/shoc_mix_strat^2
+  ! (before the min/max/grid-mesh clipping in check_length_scale_shoc_length).
+  real(rtype), intent(out) :: shoc_mix_surf (shcol, nlev)  ! [m] surface/wall (von Karman) term
+  real(rtype), intent(out) :: shoc_mix_linf (shcol, nlev)  ! [m] asymptotic (l_inf / BL-depth) term
+  real(rtype), intent(out) :: shoc_mix_strat(shcol, nlev)  ! [m] stable-stratification term (capped where N^2<=0)
 
 #ifdef SCREAM_CONFIG_IS_CMAKE
   real(rtype), optional, intent(out) :: elapsed_s ! duration of main loop in seconds
@@ -567,6 +576,16 @@ subroutine shoc_main ( &
        zt_grid,zi_grid,dz_zt,&           ! Input
        tke,shoc_thv,&                    ! Input
        brunt,shoc_mix)                   ! Output
+
+    ! Diagnostic decomposition of shoc_mix into its three component length
+    ! scales (surface/wall, asymptotic l_inf, stable stratification), in [m].
+    ! Uses the same brunt shoc_length just produced; reuses
+    ! compute_l_inf_shoc_length for l_inf. Output to history only
+    ! (SHOC_MIX_SURF/LINF/STRAT); does not feed back into the solution.
+    call compute_shoc_mix_terms(&
+       shcol,nlev,&                                    ! Input
+       tke,brunt,zt_grid,dz_zt,&                       ! Input
+       shoc_mix_surf,shoc_mix_linf,shoc_mix_strat)     ! Output
 
     ! Advance the SGS TKE equation
     call shoc_tke(&
@@ -4989,6 +5008,84 @@ subroutine compute_shoc_mix_shoc_length(nlev,shcol,tke,brunt,zt_grid,l_inf,shoc_
   enddo ! end k loop (vertical loop)
 
 end subroutine compute_shoc_mix_shoc_length
+
+subroutine compute_shoc_mix_terms(&
+     shcol,nlev,&                                    ! Input
+     tke,brunt,zt_grid,dz_zt,&                       ! Input
+     shoc_mix_surf,shoc_mix_linf,shoc_mix_strat)     ! Output
+
+  !=========================================================
+  ! Diagnostic decomposition of the SHOC mixing length (compute_shoc_mix_shoc_length)
+  ! into its three component length scales, each in [m] so they are directly
+  ! comparable to SHOC_MIX and the Larson LSCALE diagnostics.
+  !
+  ! shoc_mix = (2.8284/length_fac)*sqrt(1/(A_surf + A_linf + A_strat)), with
+  !   A_surf  = 1/(tscale*sqrt(tke)*vk*z)     (surface/wall, von Karman)
+  !   A_linf  = 1/(tscale*sqrt(tke)*l_inf)    (asymptotic / BL-depth)
+  !   A_strat = 0.01*max(brunt,0)/tke         (stable stratification)
+  ! Each component length L_k = (2.8284/length_fac)*sqrt(1/A_k), so (pre-clip)
+  !   1/shoc_mix^2 = 1/L_surf^2 + 1/L_linf^2 + 1/L_strat^2.
+  !
+  ! These three term expressions MIRROR compute_shoc_mix_shoc_length; if that
+  ! formula is ever retuned, update both. Diagnostic only: does not modify
+  ! shoc_mix. l_inf is obtained by reusing compute_l_inf_shoc_length (no
+  ! duplication of the asymptotic-length-scale calculation).
+  !=========================================================
+
+  implicit none
+
+  integer, intent(in) :: nlev, shcol
+  ! turbulent kinetic energy [m^2/s^2]
+  real(rtype), intent(in) :: tke(shcol,nlev)
+  ! brunt vaisala frequency [s-1]
+  real(rtype), intent(in) :: brunt(shcol,nlev)
+  ! heights on thermo (midpoint) grid [m]
+  real(rtype), intent(in) :: zt_grid(shcol,nlev)
+  ! layer thickness on thermo grid [m]
+  real(rtype), intent(in) :: dz_zt(shcol,nlev)
+
+  ! Component length scales [m]
+  real(rtype), intent(out) :: shoc_mix_surf (shcol,nlev)
+  real(rtype), intent(out) :: shoc_mix_linf (shcol,nlev)
+  real(rtype), intent(out) :: shoc_mix_strat(shcol,nlev)
+
+  ! LOCAL VARIABLES
+  real(rtype) :: l_inf(shcol)
+  real(rtype) :: tkes, brunt2, term_surf, term_linf, term_strat, cfac
+  integer :: i, k
+
+  ! Turnover timescale [s] (matches compute_shoc_mix_shoc_length)
+  real(rtype), parameter :: tscale = 400._rtype
+
+  ! Reuse the existing asymptotic-length-scale routine (single source of truth)
+  l_inf(:) = 0._rtype
+  call compute_l_inf_shoc_length(nlev,shcol,zt_grid,dz_zt,tke,l_inf)
+
+  cfac = 2.8284_rtype/length_fac
+
+  do k=1,nlev
+    do i=1,shcol
+      tkes = sqrt(tke(i,k))
+      brunt2 = 0._rtype
+      if (brunt(i,k) .ge. 0._rtype) brunt2 = brunt(i,k)
+
+      term_surf  = 1._rtype/(tscale*tkes*vk*zt_grid(i,k))
+      term_linf  = 1._rtype/(tscale*tkes*l_inf(i))
+      term_strat = 0.01_rtype*(brunt2/tke(i,k))
+
+      shoc_mix_surf(i,k) = cfac*sqrt(1._rtype/term_surf)
+      shoc_mix_linf(i,k) = cfac*sqrt(1._rtype/term_linf)
+      ! term_strat = 0 in neutral/unstable air (brunt<=0) -> length unbounded;
+      ! cap at maxlen so the field is finite ("stratification imposes no limit").
+      if (term_strat > 0._rtype) then
+        shoc_mix_strat(i,k) = min(maxlen, cfac*sqrt(1._rtype/term_strat))
+      else
+        shoc_mix_strat(i,k) = maxlen
+      endif
+    enddo
+  enddo
+
+end subroutine compute_shoc_mix_terms
 
 subroutine check_length_scale_shoc_length(nlev,shcol,host_dx,host_dy,shoc_mix)
   ! Do checks on the length scale.  Make sure it is not

--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -415,15 +415,17 @@ subroutine shoc_main ( &
   real(rtype) :: dz_zi(shcol,nlevi)
 
   ! Virtual potential temperature recomputed each nadv iteration from the
-  ! current substep state (thetal, qw, shoc_ql, inv_exner). The intent(in)
-  ! `thv` argument is computed once per shoc_tend_e3sm call (in shoc_intr,
-  ! before the i_shoc_main loop) and then held constant. Inside the nadv
-  ! loop here, thetal/qw/tke evolve via update_prognostics_implicit but
-  ! `thv` does not, so it goes stale. This local thv_now is used in place
-  ! of `thv` for shoc_length (-> compute_brunt_shoc_length) and the
-  ! diagnostic shoc_compute_lscale, so they see the same substep state as
-  ! the rest of the SHOC closure.
-  real(rtype) :: thv_now(shcol,nlev)
+  ! current substep state. The intent(in) `thv` argument is computed once per
+  ! shoc_tend_e3sm call (in shoc_intr, before the i_shoc_main loop) and then
+  ! held constant. Inside the nadv loop here, thetal and qw evolve via
+  ! update_prognostics_implicit and the cloud liquid shoc_ql is re-diagnosed
+  ! each substep by shoc_assumed_pdf, so the host-side `thv` goes stale. This
+  ! local shoc_thv is recomputed each substep and used in place of `thv` for
+  ! shoc_length (-> compute_brunt_shoc_length) and the diagnostic
+  ! shoc_compute_lscale, so they see the current substep state. It is built
+  ! from SHOC's own diagnosed temperature (shoc_tabs) and vapor (shoc_qv) using
+  ! the identical formula to shoc_intr's host-side thv (shoc_intr.F90:887).
+  real(rtype) :: shoc_thv(shcol,nlev)
 
   ! Surface friction velocity [m/s]
   real(rtype) :: ustar(shcol)
@@ -463,21 +465,9 @@ subroutine shoc_main ( &
                      uw_sec, vw_sec, w3,&                    ! Output (diagnostic)
                      wqls_sec, brunt, shoc_ql2)              ! Output (diagnostic)
 
-    ! Diagnostic Larson nonlocal moist length scale. Computed in F90 even
-    ! when the SHOC core runs as C++, so the LSCALE_SHOC history field is
-    ! always populated. Uses end-of-kernel state (the C++ kernel has just
-    ! evolved thetal, qw, tke, etc.). Recompute thv_now here so it is
-    ! consistent with the other end-of-kernel arrays passed in.
-    ! Formula matches pblintd_init_pot (shoc.F90:4475-4477): theta =
-    ! thetal + (Lv/cp)*qc, thv = theta * (1 + eps*qv - qc), with
-    ! qv = qw - shoc_ql.
-    thv_now(:,:) = ( thetal(:,:) + (lcond/cp) * shoc_ql(:,:) ) &
-                   * ( 1.0_rtype + eps * ( qw(:,:) - shoc_ql(:,:) ) - shoc_ql(:,:) )
-    call shoc_compute_lscale(                                 &
-         shcol, nlev, nlevi,                                  &  ! Input
-         thetal, qw, tke, thv_now,                            &  ! Input
-         pres, inv_exner, zt_grid, zi_grid,                   &  ! Input
-         lscale_shoc, lscale_up_shoc, lscale_down_shoc)          ! Output
+    ! NOTE: the diagnostic Larson length scale (shoc_compute_lscale -> LSCALE_SHOC)
+    ! is computed only in the Fortran path below, where it has been validated.
+    ! It is intentionally NOT computed here in the C++ (SCREAM CMAKE) path.
      return
   endif
 #endif
@@ -496,18 +486,6 @@ subroutine shoc_main ( &
      se_b,ke_b,wv_b,wl_b)                   ! Input/Output
 
   do t=1,nadv
-
-    ! Refresh virtual potential temperature from the current substep state.
-    ! The intent(in) `thv` argument is set once per shoc_tend_e3sm call
-    ! (in shoc_intr.F90, before the i_shoc_main loop) and then held
-    ! constant, while thetal/qw/shoc_ql evolve via update_prognostics_implicit
-    ! within this loop. Using a stale `thv` would bias compute_brunt_shoc_length
-    ! (and therefore shoc_mix above the cloud-top inversion in DYCOMS), and
-    ! would also bias the diagnostic shoc_compute_lscale at all levels.
-    ! Formula matches pblintd_init_pot (shoc.F90:4475-4477): theta = thetal
-    ! + (Lv/cp)*qc, thv = theta * (1 + eps*qv - qc), with qv = qw - shoc_ql.
-    thv_now(:,:) = ( thetal(:,:) + (lcond/cp) * shoc_ql(:,:) ) &
-                   * ( 1.0_rtype + eps * ( qw(:,:) - shoc_ql(:,:) ) - shoc_ql(:,:) )
 
     ! Check TKE to make sure values lie within acceptable
     !  bounds after host model performs horizontal advection
@@ -534,6 +512,20 @@ subroutine shoc_main ( &
     call compute_shoc_temperature(&
        shcol,nlev,thetal,shoc_ql,inv_exner,& ! Input
        shoc_tabs)                            ! Output
+
+    ! Refresh virtual potential temperature for this substep, identical in
+    ! form to shoc_intr's host-side thv (shoc_intr.F90:887):
+    !   thv = T * inv_exner * (1 + eps*qv - qc).
+    ! Built from SHOC's own diagnosed temperature (shoc_tabs) and vapor
+    ! (shoc_qv) computed just above, so shoc_thv matches the host-side thv
+    ! exactly (no theta reconstruction; the Exner factor is carried by
+    ! shoc_tabs = thetal/inv_exner + (Lv/cp)*shoc_ql). The intent(in) `thv`
+    ! is set once per shoc_tend_e3sm call and goes stale as thetal/qw evolve
+    ! (update_prognostics_implicit) and shoc_ql is re-diagnosed
+    ! (shoc_assumed_pdf) each substep; shoc_thv is used below by
+    ! shoc_compute_lscale and shoc_length (-> compute_brunt_shoc_length).
+    shoc_thv(:,:) = shoc_tabs(:,:) * inv_exner(:,:) &
+                    * ( 1.0_rtype + eps * shoc_qv(:,:) - shoc_ql(:,:) )
 
     call shoc_diag_obklen(&
        shcol,uw_sfc,vw_sfc,&                          ! Input
@@ -562,18 +554,18 @@ subroutine shoc_main ( &
     ! loop below when l_txt_write=.true.
     call shoc_compute_lscale(                                 &
          shcol, nlev, nlevi,                                  &  ! Input
-         thetal, qw, tke, thv_now,                            &  ! Input
+         thetal, qw, tke, shoc_thv,                           &  ! Input
          pres, inv_exner, zt_grid, zi_grid,                   &  ! Input
          lscale_shoc, lscale_up_shoc, lscale_down_shoc)          ! Output
 
-    ! Update the turbulent length scale.  Note: thv_now (refreshed at top
-    ! of this nadv iteration) is used instead of the intent(in) thv so
-    ! that compute_brunt_shoc_length sees the current substep state.
+    ! Update the turbulent length scale.  Note: shoc_thv (refreshed this
+    ! nadv iteration) is used instead of the intent(in) thv so that
+    ! compute_brunt_shoc_length sees the current substep state.
     call shoc_length(&
        shcol,nlev,nlevi,&                ! Input
        host_dx,host_dy,&                 ! Input
        zt_grid,zi_grid,dz_zt,&           ! Input
-       tke,thv_now,&                     ! Input
+       tke,shoc_thv,&                    ! Input
        brunt,shoc_mix)                   ! Output
 
     ! Advance the SGS TKE equation

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -473,6 +473,12 @@ end function shoc_implements_cnst
     call addfld('LSCALE_UP_SHOC',  (/'lev'/), 'A', 'm', 'SHOC-internal Larson upward length scale')
     call addfld('LSCALE_DOWN_SHOC',(/'lev'/), 'A', 'm', 'SHOC-internal Larson downward length scale')
 
+    ! Decomposition of SHOC's own mixing length SHOC_MIX into its three component
+    ! length scales (surface/wall, asymptotic l_inf, stable stratification), [m].
+    call addfld('SHOC_MIX_SURF', (/'lev'/), 'A', 'm', 'SHOC_MIX surface/wall (von Karman) component length')
+    call addfld('SHOC_MIX_LINF', (/'lev'/), 'A', 'm', 'SHOC_MIX asymptotic (l_inf) component length')
+    call addfld('SHOC_MIX_STRAT',(/'lev'/), 'A', 'm', 'SHOC_MIX stable-stratification component length (capped where N2<=0)')
+
     call add_default('SHOC_TKE', 1, ' ')
     call add_default('WTHV_SEC', 1, ' ')
     call add_default('SHOC_MIX', 1, ' ')
@@ -501,6 +507,9 @@ end function shoc_implements_cnst
     call add_default('LSCALE_SHOC',     1, ' ')
     call add_default('LSCALE_UP_SHOC',  1, ' ')
     call add_default('LSCALE_DOWN_SHOC',1, ' ')
+    call add_default('SHOC_MIX_SURF', 1, ' ')
+    call add_default('SHOC_MIX_LINF', 1, ' ')
+    call add_default('SHOC_MIX_STRAT',1, ' ')
 
     ! Add output variables from SHOC's internal substeps
 
@@ -689,6 +698,9 @@ end function shoc_implements_cnst
    real(r8) :: lscale_shoc_out     (pcols, pver)
    real(r8) :: lscale_up_shoc_out  (pcols, pver)
    real(r8) :: lscale_down_shoc_out(pcols, pver)
+   real(r8) :: shoc_mix_surf_out (pcols, pver)
+   real(r8) :: shoc_mix_linf_out (pcols, pver)
+   real(r8) :: shoc_mix_strat_out(pcols, pver)
 
    real(r8) :: wthl_output(pcols,pverp)
    real(r8) :: wqw_output(pcols,pverp)
@@ -1045,7 +1057,9 @@ end function shoc_implements_cnst
            uw_sec_out(:ncol,:), vw_sec_out(:ncol,:), w3_out(:ncol,:), & ! Output (diagnostic)
            wqls_out(:ncol,:),brunt_out(:ncol,:),rcm2(:ncol,:), &     ! Output (diagnostic)
            lscale_shoc_out(:ncol,:), lscale_up_shoc_out(:ncol,:), &  ! Output (diagnostic, NEW)
-           lscale_down_shoc_out(:ncol,:))                            ! Output (diagnostic, NEW)
+           lscale_down_shoc_out(:ncol,:), &                          ! Output (diagnostic, NEW)
+           shoc_mix_surf_out(:ncol,:), shoc_mix_linf_out(:ncol,:), & ! Output (diagnostic, NEW: shoc_mix decomposition)
+           shoc_mix_strat_out(:ncol,:))                              ! Output (diagnostic, NEW: shoc_mix decomposition)
 
       ! Write results to txt file after each shoc_main call if conditions are met.
 
@@ -1377,6 +1391,9 @@ end function shoc_implements_cnst
     call outfld('LSCALE_SHOC',     lscale_shoc_out,      pcols, lchnk)
     call outfld('LSCALE_UP_SHOC',  lscale_up_shoc_out,   pcols, lchnk)
     call outfld('LSCALE_DOWN_SHOC',lscale_down_shoc_out, pcols, lchnk)
+    call outfld('SHOC_MIX_SURF',   shoc_mix_surf_out,    pcols, lchnk)
+    call outfld('SHOC_MIX_LINF',   shoc_mix_linf_out,    pcols, lchnk)
+    call outfld('SHOC_MIX_STRAT',  shoc_mix_strat_out,   pcols, lchnk)
 
 #endif
     return

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -465,6 +465,14 @@ end function shoc_implements_cnst
     call addfld('TOT_CLOUD_FRAC',(/'lev'/), 'A', 'fraction', 'total cloud fraction')
     call addfld('PBLH',horiz_only,'A','m','PBL height')
 
+    ! Diagnostic Larson nonlocal moist length scale, computed inside
+    ! shoc_main per nadv substep. Mirror of LSCALE / LSCALE_UP / LSCALE_DOWN
+    ! (which are computed once per macmic substep in tphysbc, before shoc_main
+    ! runs). Useful for in-and-out simulations where macmic_num_steps = 1.
+    call addfld('LSCALE_SHOC',     (/'lev'/), 'A', 'm', 'SHOC-internal Larson nonlocal moist length scale')
+    call addfld('LSCALE_UP_SHOC',  (/'lev'/), 'A', 'm', 'SHOC-internal Larson upward length scale')
+    call addfld('LSCALE_DOWN_SHOC',(/'lev'/), 'A', 'm', 'SHOC-internal Larson downward length scale')
+
     call add_default('SHOC_TKE', 1, ' ')
     call add_default('WTHV_SEC', 1, ' ')
     call add_default('SHOC_MIX', 1, ' ')
@@ -490,6 +498,9 @@ end function shoc_implements_cnst
     call add_default('PRECIPITATING_ICE_FRAC',1,' ')
     call add_default('LIQ_CLOUD_FRAC',1,' ')
     call add_default('TOT_CLOUD_FRAC',1,' ')
+    call add_default('LSCALE_SHOC',     1, ' ')
+    call add_default('LSCALE_UP_SHOC',  1, ' ')
+    call add_default('LSCALE_DOWN_SHOC',1, ' ')
 
     ! Add output variables from SHOC's internal substeps
 
@@ -673,6 +684,11 @@ end function shoc_implements_cnst
    real(r8) :: wtke_sec_out(pcols,pverp), uw_sec_out(pcols,pverp)
    real(r8) :: vw_sec_out(pcols,pverp), w3_out(pcols,pverp)
    real(r8) :: wqls_out(pcols,pver), brunt_out(pcols,pver)
+
+   ! Diagnostic Larson nonlocal moist length scale (computed inside shoc_main).
+   real(r8) :: lscale_shoc_out     (pcols, pver)
+   real(r8) :: lscale_up_shoc_out  (pcols, pver)
+   real(r8) :: lscale_down_shoc_out(pcols, pver)
 
    real(r8) :: wthl_output(pcols,pverp)
    real(r8) :: wqw_output(pcols,pverp)
@@ -936,6 +952,8 @@ end function shoc_implements_cnst
        enddo
      end if
    enddo
+  
+   !! Hui added SHOCb here 
 
    !-------------------------------------------
    ! Substepping configuration (if applicable)
@@ -977,7 +995,7 @@ end function shoc_implements_cnst
 
          txtout_unit = getunit()
          open(txtout_unit, file=trim(outfname), status='replace')
-         write(txtout_unit,*) 'time, k (0 = TOM, pver - 1 = sfc), u, v, tke, qv, qc, T, P'
+         write(txtout_unit,*) 'time, k (0 = TOM, pver - 1 = sfc), u, v, tke, qv, qc, T, P, lscale, lscale_up, lscale_down'
 
          ! Send info to iulog to double check
 
@@ -999,6 +1017,8 @@ end function shoc_implements_cnst
    ! Actually call SHOC                                !
    ! ------------------------------------------------- !
    ! Note that each call includes nadv time steps of integration for SHOC
+   
+    !! Hui added SHOCc here 
 
    !============================
    do i_shoc_main = 1, n_shoc_main_calls
@@ -1023,7 +1043,9 @@ end function shoc_implements_cnst
            w_sec_out(:ncol,:), thl_sec_out(:ncol,:), qw_sec_out(:ncol,:), qwthl_sec_out(:ncol,:), & ! Output (diagnostic)
            wthl_sec_out(:ncol,:), wqw_sec_out(:ncol,:), wtke_sec_out(:ncol,:), & ! Output (diagnostic)
            uw_sec_out(:ncol,:), vw_sec_out(:ncol,:), w3_out(:ncol,:), & ! Output (diagnostic)
-           wqls_out(:ncol,:),brunt_out(:ncol,:),rcm2(:ncol,:)) ! Output (diagnostic)
+           wqls_out(:ncol,:),brunt_out(:ncol,:),rcm2(:ncol,:), &     ! Output (diagnostic)
+           lscale_shoc_out(:ncol,:), lscale_up_shoc_out(:ncol,:), &  ! Output (diagnostic, NEW)
+           lscale_down_shoc_out(:ncol,:))                            ! Output (diagnostic, NEW)
 
       ! Write results to txt file after each shoc_main call if conditions are met.
 
@@ -1037,7 +1059,10 @@ end function shoc_implements_cnst
                                      rtm(1,kk) - rcm(1,kk),     &! qv
                                      rcm(1,kk),                 &! qc
                                      thlm(1,kk) / inv_exner(1,kk) + latvap/cpair * rcm(1,kk), &! temperature
-                                     state1%pmid(1,kk)                                         ! pressure
+                                     state1%pmid(1,kk),                                       &! pressure
+                                     lscale_shoc_out(1,kk),                                   &! Larson Lscale [m]
+                                     lscale_up_shoc_out(1,kk),                                &! Larson Lscale (upward) [m]
+                                     lscale_down_shoc_out(1,kk)                                ! Larson Lscale (downward) [m]
            end do
       end if
 
@@ -1110,6 +1135,8 @@ end function shoc_implements_cnst
    call physics_ptend_init(ptend_all, state%psetcols, 'shoc')
    call physics_ptend_sum(ptend_loc,ptend_all,ncol)
    call physics_update(state1,ptend_loc,hdtime)
+
+      !! Hui added SHOCd here 
 
    ! ------------------------------------------------------------ !
    ! ------------------------------------------------------------ !
@@ -1347,6 +1374,9 @@ end function shoc_implements_cnst
     call outfld('LIQ_CLOUD_FRAC',liq_cloud_frac,pcols,lchnk)
     call outfld('TOT_CLOUD_FRAC',tot_cloud_frac,pcols,lchnk)
     call outfld('PBLH',pblh,pcols,lchnk)
+    call outfld('LSCALE_SHOC',     lscale_shoc_out,      pcols, lchnk)
+    call outfld('LSCALE_UP_SHOC',  lscale_up_shoc_out,   pcols, lchnk)
+    call outfld('LSCALE_DOWN_SHOC',lscale_down_shoc_out, pcols, lchnk)
 
 #endif
     return

--- a/components/eam/src/physics/cam/shoc_intr.F90
+++ b/components/eam/src/physics/cam/shoc_intr.F90
@@ -965,8 +965,6 @@ end function shoc_implements_cnst
      end if
    enddo
   
-   !! Hui added SHOCb here 
-
    !-------------------------------------------
    ! Substepping configuration (if applicable)
    !-------------------------------------------
@@ -1030,8 +1028,6 @@ end function shoc_implements_cnst
    ! ------------------------------------------------- !
    ! Note that each call includes nadv time steps of integration for SHOC
    
-    !! Hui added SHOCc here 
-
    !============================
    do i_shoc_main = 1, n_shoc_main_calls
 
@@ -1149,8 +1145,6 @@ end function shoc_implements_cnst
    call physics_ptend_init(ptend_all, state%psetcols, 'shoc')
    call physics_ptend_sum(ptend_loc,ptend_all,ncol)
    call physics_update(state1,ptend_loc,hdtime)
-
-      !! Hui added SHOCd here 
 
    ! ------------------------------------------------------------ !
    ! ------------------------------------------------------------ !

--- a/components/eam/src/physics/cam/shoc_lscale_mod.F90
+++ b/components/eam/src/physics/cam/shoc_lscale_mod.F90
@@ -1,0 +1,677 @@
+module shoc_lscale_mod
+
+    !---------------------------------------------------------------------------
+    ! Purpose:
+    !   SHOC-internal diagnostic Larson nonlocal moist length scale.
+    !
+    !   This is a SHOC-side parallel of the standalone routine
+    !   `calculate_lscale` in [components/eam/src/physics/cam/lscale_mod.F90],
+    !   which is used by the physics driver (tphysbc) to compute LSCALE,
+    !   LSCALE_UP, LSCALE_DOWN once per macmic substep BEFORE CLUBB or SHOC
+    !   runs.
+    !
+    !   This module exists because in turb_standalone (in-and-out) simulations
+    !   with SHOC, the macmic loop runs only once per host time step, while
+    !   SHOC subcycles internally for `nadv` substeps inside `shoc_main`.
+    !   The driver-level lscale therefore captures only the initial state,
+    !   not the per-substep evolution that the AMR/Part-1 paper requires.
+    !
+    !   Calling this module from inside SHOC's nadv loop produces lscale
+    !   values consistent with each substep's evolved state. The placement
+    !   inside `shoc_main` is right after `pblintd` and before `shoc_length`,
+    !   structurally analogous to where CLUBB calls its own
+    !   `compute_mixing_length` inside `advance_clubb_core`.
+    !
+    !   The algorithm is a direct port of the workhorse
+    !   `compute_mixing_length_standalone` (Larson nonlocal moist length scale,
+    !   Golaz et al. 2002 JAS Vol. 59, pp. 3540-3551, Section 3b "Eddy length
+    !   formulation"), with two changes:
+    !
+    !   (a) Precision: `rtype` (configurable via SHOC's physics_utils) instead
+    !       of hardcoded `r8`. SHOC may run in single precision under SCREAM
+    !       CMAKE builds; the wrapper code stays consistent with the rest of
+    !       SHOC.
+    !
+    !   (b) Inputs: takes SHOC's already-evolved thermodynamic state directly
+    !       (thetal -> thlm, qw -> rtm, thv -> thvm and thv_ds, inv_exner is
+    !       inverted to give CLUBB-convention exner). The standalone version
+    !       in lscale_mod.F90 recomputes these from T, p, qv, qc using CLUBB
+    !       formulas; here we skip that step because SHOC has the same
+    !       quantities already computed and self-consistent with the rest of
+    !       the SHOC closure.
+    !
+    !   Validation strategy: compare LSCALE_SHOC (from this module) against
+    !   LSCALE (from lscale_mod, via tphysbc) at the first SHOC substep of
+    !   the first macmic substep. They should match closely but not bit-for-
+    !   bit (TKE source differs slightly: physpkg uses pbuf-stored interface-grid
+    !   TKE from the previous host step; whereas this routine builds interface TKE
+    !   on the fly from SHOC's prognostic midpoint-grid TKE via linear average).
+    !
+    ! Provenance:
+    !   Original CLUBB algorithm: Larson, Golaz et al.
+    !   Standalone E3SM port    : H. Xiao
+    !   SHOC-side parallel port : M. Chinita, 2026
+    !---------------------------------------------------------------------------
+
+    use physics_utils, only: rtype
+
+    implicit none
+
+    private
+    public :: shoc_compute_lscale
+
+    contains
+
+!=============================================================================
+subroutine shoc_compute_lscale( &
+                shcol, nlev, nlevi,                              &  ! in: dims
+                thetal, qw, tke, thv,                            &  ! in: SHOC state on midpoints (top->bottom, no ghost)
+                pres, inv_exner,                                 &  ! in: pres on midpoints, 1/Exner on midpoints
+                zt_grid, zi_grid,                                &  ! in: heights AGL on midpoints/interfaces
+                lscale_out, lscale_up_out, lscale_down_out)         ! out: midpoint, top->bottom, no ghost
+
+    !-----------------------------------------------------------------------
+    ! Wrapper: per-column translation between SHOC's grid convention
+    ! (top-to-bottom, no ghost) and the CLUBB-internal convention required
+    ! by `compute_mixing_length_shoc` (bottom-to-top, with one ghost level
+    ! below the surface for thermodynamic-grid variables).
+    !-----------------------------------------------------------------------
+
+    implicit none
+
+    !-----------------
+    ! Arguments
+    !-----------------
+    integer,     intent(in) :: shcol, nlev, nlevi  ! nlevi = nlev + 1
+
+    real(rtype), intent(in)  :: thetal   (shcol, nlev)    ! liq water pot. temp [K]
+    real(rtype), intent(in)  :: qw       (shcol, nlev)    ! total water mixing ratio [kg/kg]
+    real(rtype), intent(in)  :: tke      (shcol, nlev)    ! turbulent kinetic energy [m^2/s^2]
+    real(rtype), intent(in)  :: thv      (shcol, nlev)    ! virtual potential temperature [K]
+    real(rtype), intent(in)  :: pres     (shcol, nlev)    ! pressure [Pa]
+    real(rtype), intent(in)  :: inv_exner(shcol, nlev)    ! 1/Exner = (p0/p)^(Rd/cp) [-]
+    real(rtype), intent(in)  :: zt_grid  (shcol, nlev)    ! height AGL on midpoints [m]
+    real(rtype), intent(in)  :: zi_grid  (shcol, nlevi)   ! height AGL on interfaces [m]
+
+    real(rtype), intent(out) :: lscale_out     (shcol, nlev)
+    real(rtype), intent(out) :: lscale_up_out  (shcol, nlev)
+    real(rtype), intent(out) :: lscale_down_out(shcol, nlev)
+
+    !-----------------------------------------------------------------------
+    ! Local arrays. Their shape and direction of indexing follow CLUBB:
+    !  - Variables defined on thermodynamic levels (corresponding to SHOC's
+    !    layer midpoints) have an extra ghost level below the surface;
+    !  - Level indices start from the surface and increase upward.
+    !-----------------------------------------------------------------------
+    real(rtype) :: zt       (nlevi)
+    real(rtype) :: zm       (nlevi)
+    real(rtype) :: dzm      (nlevi)
+    real(rtype) :: invrs_dzm(nlevi)
+
+    real(rtype) :: thvm   (nlevi)
+    real(rtype) :: thlm   (nlevi)
+    real(rtype) :: rtm    (nlevi)
+    real(rtype) :: em     (nlevi)
+    real(rtype) :: p_in_Pa(nlevi)
+    real(rtype) :: exner  (nlevi)        ! NB: this stores (p/p0)^(Rd/cp) =
+                                          ! 1/inv_exner; this matches the
+                                          ! convention that
+                                          ! compute_mixing_length_shoc expects
+                                          ! (T = thetal * exner)
+    real(rtype) :: thv_ds (nlevi)
+
+    real(rtype) :: lscale_tmp     (nlevi)
+    real(rtype) :: lscale_up_tmp  (nlevi)
+    real(rtype) :: lscale_down_tmp(nlevi)
+
+    integer :: ii, kk, kflip, k_shoc
+
+    !-----------------------------------------------------------------------
+    ! Process each column independently.
+    !-----------------------------------------------------------------------
+    do ii = 1, shcol
+
+       !====================================================
+       ! 1. Prepare input variables for this column,
+       !    flipping vertical indexing to CLUBB's convention.
+       !====================================================
+       do kk = 1, nlev
+
+          !--------------------------------------------------
+          ! 1.1 Thermodynamic-level variables
+          !     CLUBB index kk+1 (slot 1 reserved for ghost),
+          !     SHOC index kflip = nlev - kk + 1.
+          !--------------------------------------------------
+          kflip = nlev - kk + 1
+
+          thlm   (kk+1) = thetal   (ii, kflip)
+          rtm    (kk+1) = qw       (ii, kflip)
+          thvm   (kk+1) = thv      (ii, kflip)
+          ! thv_ds is set to the moist theta_v, following the convention used
+          ! in clubb_intr.F90 (clubb_tend_cam: thv_ds_zt = moist thv) and
+          ! mirrored in calculate_lscale (lscale_mod.F90:142). Inside
+          ! compute_mixing_length, this is treated as a "reference theta"
+          ! used to recompute thv from (thl, rt, qc) for the parcel.
+          thv_ds (kk+1) = thv      (ii, kflip)
+          p_in_Pa(kk+1) = pres     (ii, kflip)
+          ! SHOC's inv_exner = (p0/p)^(R/cp). The algorithm needs the
+          ! "standard" Exner = (p/p0)^(R/cp) = 1/inv_exner.
+          exner  (kk+1) = 1.0_rtype / inv_exner(ii, kflip)
+          ! zt_grid is already height above ground (subtraction of surface
+          ! interface height done in shoc_intr.F90 before shoc_main is called).
+          zt     (kk+1) = zt_grid  (ii, kflip)
+
+       end do
+
+       !-----------------------------------------------------------
+       ! 1.2 Fill ghost level (slot 1, below ground) for zt-grid
+       !     variables. Mirror zt; zero-gradient for the rest.
+       !-----------------------------------------------------------
+       zt     (1) = -1.0_rtype * zt(2)
+       exner  (1) = exner  (2)
+       p_in_Pa(1) = p_in_Pa(2)
+       rtm    (1) = rtm    (2)
+       thlm   (1) = thlm   (2)
+       thv_ds (1) = thv_ds (2)
+       thvm   (1) = thvm   (2)
+
+       !-----------------------------------------------------------
+       ! 1.3 Momentum-level variables (interfaces). NO ghost level
+       !     on this grid -- all `nlevi` slots are real interfaces,
+       !     reordered surface-up.
+       !-----------------------------------------------------------
+       ! Heights: zi_grid is already AGL.
+       do kk = 1, nlev
+          zm(kk) = zi_grid(ii, nlevi - kk + 1)
+       end do
+       zm(nlevi) = zi_grid(ii, 1)   ! TOM interface
+
+       !-----------------------------------------------------------
+       ! 1.4 TKE on momentum (interface) levels.
+       !
+       !     Inside shoc_main, only midpoint TKE is available (the
+       !     interpolation to interface grid happens in shoc_intr,
+       !     via linear_interp, AFTER shoc_main returns and writes
+       !     to pbuf 'tke').
+       !
+       !     We replicate that same linear-in-z interpolation here
+       !     so LSCALE_SHOC and the driver-level LSCALE see
+       !     consistently-interpolated interface TKE. The remaining
+       !     LSCALE_SHOC vs LSCALE difference is then the
+       !     time-state difference only (LSCALE uses pbuf 'tke'
+       !     populated at the previous host step; LSCALE_SHOC uses
+       !     within-substep midpoint TKE interpolated on the fly).
+       !
+       !     For interior interfaces (k_shoc = 2..nlev, between two
+       !     midpoints), the formula matches linear_interp's
+       !     interior branch [shoc.F90:4795-4798]. The surface and
+       !     TOM interfaces use linear extrapolation from the two
+       !     nearest midpoints, also matching linear_interp's
+       !     boundary branches [4791-4793, 4801-4803].
+       !-----------------------------------------------------------
+
+       ! Interior interfaces. CLUBB kk=2..nlev maps to SHOC
+       ! interface index k_shoc = nlevi-kk+1 in 2..nlev.
+       do kk = 2, nlev
+          k_shoc = nlevi - kk + 1
+          ! Surrounding SHOC midpoints: k_shoc-1 (above), k_shoc (below).
+          em(kk) = tke(ii, k_shoc-1) &
+                   + ( tke(ii, k_shoc) - tke(ii, k_shoc-1) ) &
+                   * ( zi_grid(ii, k_shoc) - zt_grid(ii, k_shoc-1) ) &
+                   / ( zt_grid(ii, k_shoc) - zt_grid(ii, k_shoc-1) )
+       end do
+
+       ! Surface interface (CLUBB kk=1, SHOC k_shoc=nlevi):
+       ! linear extrapolation using the two lowest midpoints.
+       em(1) = tke(ii, nlev-1) &
+               + ( tke(ii, nlev) - tke(ii, nlev-1) ) &
+               * ( zi_grid(ii, nlevi) - zt_grid(ii, nlev-1) ) &
+               / ( zt_grid(ii, nlev)  - zt_grid(ii, nlev-1) )
+
+       ! Top-of-model interface (CLUBB kk=nlevi, SHOC k_shoc=1):
+       ! linear extrapolation using the two highest midpoints.
+       em(nlevi) = tke(ii, 1) &
+                   + ( tke(ii, 2) - tke(ii, 1) ) &
+                   * ( zi_grid(ii, 1) - zt_grid(ii, 1) ) &
+                   / ( zt_grid(ii, 2) - zt_grid(ii, 1) )
+
+       !-----------------------------------------------------------
+       ! 1.5 Grid spacing and inverse spacing on momentum grid.
+       !-----------------------------------------------------------
+       do kk = 1, nlev
+          dzm      (kk) = zt(kk+1) - zt(kk)
+          invrs_dzm(kk) = 1.0_rtype / dzm(kk)
+       end do
+       dzm      (nlevi) = dzm      (nlev)   ! never used inside the algorithm
+       invrs_dzm(nlevi) = invrs_dzm(nlev)
+
+       !====================================================
+       ! 2. Run the algorithm on this column.
+       !====================================================
+       call compute_mixing_length_shoc( &
+            nlevi, zt, zm, dzm, invrs_dzm, &
+            thvm, thlm, rtm, em, p_in_Pa, exner, thv_ds, &
+            lscale_tmp, lscale_up_tmp, lscale_down_tmp )
+
+       !====================================================
+       ! 3. Flip outputs back to SHOC convention (top-to-
+       !    bottom, no ghost). The ghost level (CLUBB index 1)
+       !    is dropped on the way out.
+       !====================================================
+       do kk = 1, nlev
+          lscale_out     (ii, kk) = lscale_tmp     (nlevi - kk + 1)
+          lscale_up_out  (ii, kk) = lscale_up_tmp  (nlevi - kk + 1)
+          lscale_down_out(ii, kk) = lscale_down_tmp(nlevi - kk + 1)
+       end do
+
+    end do  ! ii = 1, shcol
+
+end subroutine shoc_compute_lscale
+
+!=============================================================================
+subroutine compute_mixing_length_shoc( &
+    nzmax, zt, zm, dzm, invrs_dzm, &
+    thvm, thlm, rtm, em, p_in_Pa, exner, thv_ds, &
+    Lscale, Lscale_up, Lscale_down )
+
+    !---------------------------------------------------------------------
+    ! Larson's 5th moist, nonlocal length scale.
+    ! Direct port of `compute_mixing_length_standalone` from
+    ! [components/eam/src/physics/cam/lscale_mod.F90:209-978] by H. Xiao,
+    ! with r8 -> rtype substitution. The algorithm is unchanged.
+    !
+    ! References:
+    !   Section 3b ("Eddy length formulation") of
+    !   "A PDF-Based Model for Boundary Layer Clouds. Part I:
+    !    Method and Model Description", Golaz, et al. (2002),
+    !   JAS, Vol. 59, pp. 3540--3551.
+    !
+    ! See lscale_mod.F90 for full algorithmic documentation; the comments
+    ! in this routine are kept terse to avoid duplication.
+    !---------------------------------------------------------------------
+
+    use shr_const_mod, only: shr_const_rdair, shr_const_cpdair, shr_const_latvap, &
+                             shr_const_mwwv, shr_const_mwdair, shr_const_g
+
+    implicit none
+
+    ! Constants. Use the same host-model constants the lscale_mod standalone
+    ! uses, so LSCALE_SHOC and LSCALE share thermodynamic constants and the
+    ! validation comparison isn't biased by constant choice.
+    real(rtype), parameter :: &
+        Cp   = shr_const_cpdair, &
+        Lv   = shr_const_latvap, &
+        Rd   = shr_const_rdair,  &
+        ep   = shr_const_mwwv / shr_const_mwdair, &  ! ~ 0.622
+        ep1  = (1.0_rtype - ep) / ep, &              ! ~ 0.61
+        ep2  = 1.0_rtype / ep, &                     ! ~ 1.61
+        grav = shr_const_g, &
+        zero_threshold = 0.0_rtype, &
+        eps_div = 1.0e-10_rtype  ! small number to guard divides
+
+    intrinsic :: min, max, sqrt
+
+    ! Almost-Constant Parameters (matching lscale_mod.F90 exactly so
+    ! validation against LSCALE is meaningful).
+    real(rtype), parameter ::  &
+      zlmin               = 0.1_rtype,       &           ! [m]
+      Lscale_sfclyr_depth = 500.0_rtype,     &           ! [m]
+      em_min              = 1.5_rtype * (2.0e-2_rtype)**2, &  ! [m^2/s^2]
+      lmin                = 40.0_rtype * 0.1_rtype       ! [m]
+
+    ! Tunable parameters (hardcoded to match lscale_mod.F90 / clubb_mu = 5e-4).
+    ! TODO: expose `mu` via SHOC namelist if SHOC tuning warrants.
+    ! TODO: replace `Lscale_max` hardcode with 0.25 * min(host_dx, host_dy)
+    !       once we plumb the host-grid spacing into this module.
+    real(rtype), parameter ::  &
+      mu         = 5.0e-4_rtype, &
+      Lscale_max = 0.25_rtype * 25000.0_rtype
+
+    ! Input/Output
+    integer,     intent(in)  :: nzmax
+    real(rtype), dimension(nzmax), intent(in) :: &
+      thvm, thlm, rtm, em, exner, p_in_Pa, thv_ds, &
+      zt, zm, dzm, invrs_dzm
+    real(rtype), dimension(nzmax), intent(out) :: &
+      Lscale, Lscale_up, Lscale_down
+
+    ! Local Variables
+    integer :: i, j
+
+    real(rtype) :: tke, CAPE_incr
+    real(rtype) :: dCAPE_dz_j, dCAPE_dz_j_minus_1, dCAPE_dz_j_plus_1
+
+    real(rtype), dimension(nzmax) :: &
+        exp_mu_dzm, invrs_dzm_on_mu, grav_on_thvm, &
+        thl_par_j_precalc, rt_par_j_precalc, &
+        tke_i, &
+        thl_par_1, rt_par_1, tl_par_1, &
+        rsatl_par_1, s_par_1, rc_par_1, thv_par_1, &
+        dCAPE_dz_1, CAPE_incr_1, &
+        Lv_coef, entrain_coef
+
+    real(rtype) :: lminh
+    real(rtype) :: thl_par_j, rt_par_j, rc_par_j, thv_par_j
+    real(rtype) :: tl_par_j, rsatl_par_j, s_par_j
+    real(rtype) :: Lscale_up_max_alt, Lscale_down_min_alt
+    real(rtype) :: Lv2_coef, tl_par_j_sqd, invrs_dCAPE_diff, &
+                    invrs_Lscale_sfclyr_depth
+
+    ! ---- Begin Code ----
+
+    ! Initialize arrays and precalculate values for computational efficiency.
+    do i = 1, nzmax
+        Lscale_up(i)        = zlmin
+        Lscale_down(i)      = zlmin
+        exp_mu_dzm(i)       = exp( -mu * dzm(i) )
+        invrs_dzm_on_mu(i)  = ( invrs_dzm(i) ) / mu
+        grav_on_thvm(i)     = grav / thvm(i)
+        Lv_coef(i)          = Lv / ( exner(i) * Cp ) - ep2 * thv_ds(i)
+        entrain_coef(i)     = ( 1.0_rtype - exp_mu_dzm(i) ) * invrs_dzm_on_mu(i)
+    end do
+
+    ! Avoid uninitialized memory at the ghost level (these are dropped on output).
+    Lscale_up  (1) = 0.0_rtype
+    Lscale_down(1) = 0.0_rtype
+
+    Lv2_coef                  = ep * Lv**2 / ( Rd * Cp )
+    invrs_Lscale_sfclyr_depth = 1.0_rtype / Lscale_sfclyr_depth
+
+    ! Calculate initial TKE for zt levels by linear interpolation, following CLUBB.
+    do i = 2, nzmax
+      tke_i(i) = em(i)   * ( zt(i) - zm(i-1) ) + &
+                 em(i-1) * ( zm(i) - zt(i)   )
+      tke_i(i) = max( tke_i(i) / (zm(i) - zm(i-1)), em_min )
+    end do
+    tke_i(1) = (zt(1) - zm(1)) * (em(2) - em(1)) / (zm(2) - zm(1)) + em(1)
+    tke_i(1) = max( tke_i(1), em_min )
+
+    ! ============== Upwards Length Scale Calculation ==============
+
+    ! Precalculate values for upward Lscale.
+    do j = 2, nzmax-1
+        thl_par_j_precalc(j) = thlm(j) - thlm(j-1) * exp_mu_dzm(j-1)  &
+                               - ( thlm(j) - thlm(j-1) ) * entrain_coef(j-1)
+        rt_par_j_precalc(j)  = rtm(j) - rtm(j-1) * exp_mu_dzm(j-1)  &
+                               - ( rtm(j) - rtm(j-1) ) * entrain_coef(j-1)
+    end do
+
+    ! Initial parcel properties at each grid level (vectorized first level).
+    do j = 3, nzmax
+        thl_par_1(j) = thlm(j) - ( thlm(j) - thlm(j-1) ) * entrain_coef(j-1)
+        tl_par_1 (j) = thl_par_1(j) * exner(j)
+        rt_par_1 (j) = rtm(j)  - ( rtm(j)  - rtm(j-1)  ) * entrain_coef(j-1)
+    end do
+
+    rsatl_par_1(3:) = sat_mixrat_liq_shoc( p_in_Pa(3:), tl_par_1(3:) )
+
+    do j = 3, nzmax
+        tl_par_j_sqd = tl_par_1(j)**2
+
+        ! s = (rt - rsatl) / (1 + beta*rsatl); simplified by *tl^2.
+        s_par_1 (j) = ( rt_par_1(j) - rsatl_par_1(j) ) * tl_par_j_sqd &
+                      / ( tl_par_j_sqd + Lv2_coef * rsatl_par_1(j) )
+
+        rc_par_1(j) = max( s_par_1(j), zero_threshold )
+        thv_par_1(j) = thl_par_1(j) + ep1 * thv_ds(j) * rt_par_1(j) + Lv_coef(j) * rc_par_1(j)
+
+        dCAPE_dz_1 (j) = grav_on_thvm(j) * ( thv_par_1(j) - thvm(j) )
+        ! Trapezoid; dCAPE at z_0 = 0 for this initial calculation.
+        CAPE_incr_1(j) = 0.5_rtype * dCAPE_dz_1(j) * dzm(j-1)
+    end do
+
+    Lscale_up_max_alt = 0.0_rtype
+    do i = 2, nzmax-2
+
+        if ( tke_i(i) + CAPE_incr_1(i+1) > 0.0_rtype ) then
+
+            tke = tke_i(i) + CAPE_incr_1(i+1)
+            j   = i + 2
+
+            thl_par_j          = thl_par_1(i+1)
+            rt_par_j           = rt_par_1(i+1)
+            dCAPE_dz_j_minus_1 = dCAPE_dz_1(i+1)
+
+            do while ( j < nzmax )
+
+                thl_par_j = thl_par_j_precalc(j) + thl_par_j * exp_mu_dzm(j-1)
+                rt_par_j  = rt_par_j_precalc (j) + rt_par_j  * exp_mu_dzm(j-1)
+
+                tl_par_j     = thl_par_j * exner(j)
+                rsatl_par_j  = sat_mixrat_liq_shoc( p_in_Pa(j), tl_par_j )
+                tl_par_j_sqd = tl_par_j**2
+
+                s_par_j  = ( rt_par_j - rsatl_par_j ) * tl_par_j_sqd &
+                           / ( tl_par_j_sqd + Lv2_coef * rsatl_par_j )
+                rc_par_j = max( s_par_j, zero_threshold )
+
+                thv_par_j  = thl_par_j + ep1 * thv_ds(j) * rt_par_j  &
+                             + Lv_coef(j) * rc_par_j
+
+                dCAPE_dz_j = grav_on_thvm(j) * ( thv_par_j - thvm(j) )
+                CAPE_incr  = 0.5_rtype * ( dCAPE_dz_j + dCAPE_dz_j_minus_1 ) * dzm(j-1)
+
+                if ( tke + CAPE_incr <= 0.0_rtype ) exit
+
+                dCAPE_dz_j_minus_1 = dCAPE_dz_j
+                tke                = tke + CAPE_incr
+                j                  = j + 1
+            end do
+
+            Lscale_up(i) = Lscale_up(i) + zt(j-1) - zt(i)
+
+            if ( j < nzmax ) then
+                if ( abs( dCAPE_dz_j - dCAPE_dz_j_minus_1 ) * 2 <= &
+                     abs( dCAPE_dz_j + dCAPE_dz_j_minus_1 ) * eps_div ) then
+                    ! dCAPE/dz constant -> linear-in-z exhaustion.
+                    Lscale_up(i) = Lscale_up(i) + ( - tke / dCAPE_dz_j )
+                else
+                    ! Generic case: quadratic in z.
+                    invrs_dCAPE_diff = 1.0_rtype / ( dCAPE_dz_j - dCAPE_dz_j_minus_1 )
+                    Lscale_up(i) = Lscale_up(i) &
+                                   - dCAPE_dz_j_minus_1 * invrs_dCAPE_diff * dzm(j-1) &
+                                   - sqrt( dCAPE_dz_j_minus_1**2 &
+                                            - 2.0_rtype * tke * invrs_dzm(j-1) &
+                                              * ( dCAPE_dz_j - dCAPE_dz_j_minus_1 ) ) &
+                                     * invrs_dCAPE_diff * dzm(j-1)
+                end if
+            end if
+
+        else  ! TKE exhausted within first grid level
+            Lscale_up(i) = Lscale_up(i) - sqrt( - 2.0_rtype * tke_i(i) &
+                                                 * dzm(i) * dCAPE_dz_1(i+1) ) &
+                                          / dCAPE_dz_1(i+1)
+        end if
+
+        ! Monotonicity (smoothing) constraint for nonlocality.
+        if ( zt(i) + Lscale_up(i) < Lscale_up_max_alt ) then
+            Lscale_up(i) = Lscale_up_max_alt - zt(i)
+        else
+            Lscale_up_max_alt = Lscale_up(i) + zt(i)
+        end if
+
+    end do
+
+    ! ============== Downwards Length Scale Calculation ==============
+
+    do j = 2, nzmax-1
+        thl_par_j_precalc(j) = thlm(j) - thlm(j+1) * exp_mu_dzm(j)  &
+                               - ( thlm(j) - thlm(j+1) ) * entrain_coef(j)
+        rt_par_j_precalc(j)  = rtm(j) - rtm(j+1) * exp_mu_dzm(j)  &
+                               - ( rtm(j) - rtm(j+1) ) * entrain_coef(j)
+    end do
+
+    do j = 2, nzmax-1
+        thl_par_1(j) = thlm(j) - ( thlm(j) - thlm(j+1) )  * entrain_coef(j)
+        tl_par_1 (j) = thl_par_1(j) * exner(j)
+        rt_par_1 (j) = rtm(j)  - ( rtm(j)  - rtm(j+1)  ) * entrain_coef(j)
+    end do
+
+    rsatl_par_1(2:) = sat_mixrat_liq_shoc( p_in_Pa(2:), tl_par_1(2:) )
+
+    do j = 2, nzmax-1
+        tl_par_j_sqd = tl_par_1(j)**2
+        s_par_1 (j) = ( rt_par_1(j) - rsatl_par_1(j) ) * tl_par_j_sqd &
+                      / ( tl_par_j_sqd + Lv2_coef * rsatl_par_1(j) )
+        rc_par_1(j) = max( s_par_1(j), zero_threshold )
+        thv_par_1(j) = thl_par_1(j) + ep1 * thv_ds(j) * rt_par_1(j) + Lv_coef(j) * rc_par_1(j)
+
+        dCAPE_dz_1 (j) = grav_on_thvm(j) * ( thv_par_1(j) - thvm(j) )
+        CAPE_incr_1(j) = 0.5_rtype * dCAPE_dz_1(j) * dzm(j)
+    end do
+
+    Lscale_down_min_alt = zt(nzmax)
+    do i = nzmax, 3, -1
+
+        if ( tke_i(i) - CAPE_incr_1(i-1) > 0.0_rtype ) then
+
+            tke = tke_i(i) - CAPE_incr_1(i-1)
+            j   = i - 2
+
+            thl_par_j         = thl_par_1(i-1)
+            rt_par_j          = rt_par_1(i-1)
+            dCAPE_dz_j_plus_1 = dCAPE_dz_1(i-1)
+
+            do while ( j >= 2 )
+
+                thl_par_j = thl_par_j_precalc(j) + thl_par_j * exp_mu_dzm(j)
+                rt_par_j  = rt_par_j_precalc (j) + rt_par_j  * exp_mu_dzm(j)
+
+                tl_par_j     = thl_par_j * exner(j)
+                rsatl_par_j  = sat_mixrat_liq_shoc( p_in_Pa(j), tl_par_j )
+                tl_par_j_sqd = tl_par_j**2
+
+                s_par_j  = ( rt_par_j - rsatl_par_j ) * tl_par_j_sqd &
+                           / ( tl_par_j_sqd + Lv2_coef * rsatl_par_j )
+                rc_par_j = max( s_par_j, zero_threshold )
+
+                thv_par_j = thl_par_j + ep1 * thv_ds(j) * rt_par_j + Lv_coef(j) * rc_par_j
+
+                dCAPE_dz_j = grav_on_thvm(j) * ( thv_par_j - thvm(j) )
+                CAPE_incr  = 0.5_rtype * ( dCAPE_dz_j + dCAPE_dz_j_plus_1 ) * dzm(j)
+
+                if ( tke - CAPE_incr <= 0.0_rtype ) exit
+
+                dCAPE_dz_j_plus_1 = dCAPE_dz_j
+                tke               = tke - CAPE_incr
+                j                 = j - 1
+            end do
+
+            Lscale_down(i) = Lscale_down(i) + zt(i) - zt(j+1)
+
+            if ( j >= 2 ) then
+                if ( abs( dCAPE_dz_j - dCAPE_dz_j_plus_1 ) * 2 <= &
+                     abs( dCAPE_dz_j + dCAPE_dz_j_plus_1 ) * eps_div ) then
+                    Lscale_down(i) = Lscale_down(i) + ( tke / dCAPE_dz_j )
+                else
+                    invrs_dCAPE_diff = 1.0_rtype / ( dCAPE_dz_j - dCAPE_dz_j_plus_1 )
+                    Lscale_down(i) = Lscale_down(i) &
+                                     - dCAPE_dz_j_plus_1 * invrs_dCAPE_diff * dzm(j) &
+                                     + sqrt( dCAPE_dz_j_plus_1**2 &
+                                             + 2.0_rtype * tke * invrs_dzm(j)  &
+                                               * ( dCAPE_dz_j - dCAPE_dz_j_plus_1 ) ) &
+                                       * invrs_dCAPE_diff * dzm(j)
+                end if
+            end if
+
+        else
+            Lscale_down(i) = Lscale_down(i) + sqrt( 2.0_rtype * tke_i(i) &
+                                                    * dzm(i-1) * dCAPE_dz_1(i-1) ) &
+                                              / dCAPE_dz_1(i-1)
+        end if
+
+        if ( zt(i) - Lscale_down(i) > Lscale_down_min_alt ) then
+            Lscale_down(i) = zt(i) - Lscale_down_min_alt
+        else
+            Lscale_down_min_alt = zt(i) - Lscale_down(i)
+        end if
+
+    end do
+
+    ! ============== Final Lscale Calculation ==============
+
+    do i = 2, nzmax, 1
+        ! Linear taper of the surface-layer minimum from `lmin` at the
+        ! surface to zero at Lscale_sfclyr_depth above the ground.
+        lminh = max( zero_threshold, Lscale_sfclyr_depth - ( zt(i) - zm(1) ) ) &
+                    * lmin * invrs_Lscale_sfclyr_depth
+        Lscale_up  (i) = max( lminh, Lscale_up  (i) )
+        Lscale_down(i) = max( lminh, Lscale_down(i) )
+        Lscale     (i) = sqrt( Lscale_up(i) * Lscale_down(i) )
+    end do
+
+    ! Boundary values (top and ghost). The ghost (i=1) is dropped on output.
+    Lscale(1)     = Lscale(2)
+    Lscale(nzmax) = Lscale(nzmax-1)
+
+    ! Cap at maximum (intended to let host model take over deep convection).
+    Lscale = min( Lscale, Lscale_max )
+
+    return
+end subroutine compute_mixing_length_shoc
+
+!=============================================================================
+elemental function sat_mixrat_liq_shoc(p_in_Pa, T_in_K) result(rsat)
+   !---------------------------------------------------------------------
+   ! Saturation mixing ratio of liquid water (Emanuel 1994, eqn. 4.4.14).
+   ! Direct port of `sat_mixrat_liq_clubb` from lscale_mod.F90:980-1024.
+   !---------------------------------------------------------------------
+
+   implicit none
+
+   real(rtype), intent(in) :: p_in_Pa, T_in_K
+
+   real(rtype), parameter :: ep = 0.622_rtype  ! Rd/Rv
+
+   real(rtype) :: rsat
+   real(rtype) :: esatv
+
+   esatv = sat_vapor_press_liq_flatau_shoc(T_in_K)
+
+   ! Guard against pressure approaching saturation vapor pressure.
+   if (p_in_Pa - esatv < 1.0_rtype) then
+      rsat = ep
+   else
+      rsat = ep * esatv / (p_in_Pa - esatv)
+   end if
+
+   return
+end function sat_mixrat_liq_shoc
+
+!=============================================================================
+elemental function sat_vapor_press_liq_flatau_shoc(T_in_K) result(esat)
+   !---------------------------------------------------------------------
+   ! Saturation vapor pressure over water via the Flatau et al. (1992)
+   ! 8th-order polynomial fit (Table 4 of Flatau, Walko & Cotton 1992,
+   ! J. Appl. Met. 31, 1507-1513), in the factored form computed by
+   ! G. Huebler (CLUBB issue 834) for cpu pipelining.
+   ! Direct port of `sat_vapor_press_liq_flatau_clubb` from
+   ! lscale_mod.F90:1026-1120.
+   !---------------------------------------------------------------------
+
+   implicit none
+
+   real(rtype), parameter :: min_T_in_C = -85.0_rtype, &
+                              T_freeze_K = 273.15_rtype
+
+   real(rtype), intent(in) :: T_in_K
+
+   real(rtype) :: esat
+   real(rtype) :: T_in_C, T_in_C_sqd
+
+   T_in_C = T_in_K - T_freeze_K
+   ! The polynomial is only valid out to -85 deg_C.
+   T_in_C = max(T_in_C, min_T_in_C)
+
+   T_in_C_sqd = T_in_C**2
+
+   esat = -3.21582393e-14_rtype * (T_in_C - 646.5835252598777_rtype) &
+                               * (T_in_C +  90.72381630364440_rtype) &
+                               * (T_in_C_sqd + 111.0976961559954_rtype * T_in_C + 6459.629194243118_rtype) &
+                               * (T_in_C_sqd + 152.3131930092453_rtype * T_in_C + 6499.774954705265_rtype) &
+                               * (T_in_C_sqd + 174.4279584934021_rtype * T_in_C + 7721.679732114084_rtype)
+
+   return
+end function sat_vapor_press_liq_flatau_shoc
+
+end module shoc_lscale_mod


### PR DESCRIPTION
Adds new SHOC diagnostics and one fix through a new module (shoc_lscale_mod.F90) plus edits to shoc.F90 and shoc_intr.F90. Validated in SCM on the default DYCOMS RF01.

1. CLUBB length-scale diagnostic — new subroutine shoc_compute_lscale (in shoc_lscale_mod.F90), called from shoc_main, evaluates the host-side calculate_lscale on SHOC's own state → LSCALE_SHOC/_UP/_DOWN. Pure diagnostic.

2. thv refresh — fixes thv staleness inside shoc_main through a new variable called shoc_thv. Briefly, shoc_thv is recomputed each nadv substep (the host thv goes stale as thetal/qw evolve). Changes answers for nadv > 1; mac_only no-op verified to machine precision. Note, shoc_thv is built from SHOC's diagnosed temperature, so it keeps the Exner factor on the condensate term that the earlier thv_now was missing. shoc_thv now uses the same thv formula as in shoc_intr.

3. SHOC_MIX terms added to h0 output file — SHOC_MIX_SURF/LINF/STRAT, the three component length scales of SHOC_MIX (quadrature). Pure diagnostic. 

New h0 fields are add_default. 