### PR TITLE
Fix stale thv in shoc_main substep loop (EAM Fortran + EAMxx C++)

### DIFF
--- a/components/eam/src/physics/cam/shoc.F90
+++ b/components/eam/src/physics/cam/shoc.F90
@@ -373,6 +373,15 @@ subroutine shoc_main ( &
   real(rtype) :: shoc_qv(shcol,nlev)
   ! SHOC temperature [K]
   real(rtype) :: shoc_tabs(shcol,nlev)
+  ! Virtual potential temperature seen by the current SHOC substep [K].
+  ! The intent(in) thv argument is computed once per shoc_main call by the
+  ! host model and then held constant, while thetal and qw evolve each
+  ! substep (update_prognostics_implicit) and shoc_ql is re-diagnosed
+  ! each substep (shoc_assumed_pdf).  When nadv > 1, substeps beyond the
+  ! first would otherwise use a stale thv in shoc_length
+  ! (-> compute_brunt_shoc_length).  shoc_thv equals thv on the first
+  ! substep and is refreshed from SHOC's own diagnosed state thereafter.
+  real(rtype) :: shoc_thv(shcol,nlev)
 
   ! Grid difference centereted on thermo grid [m]
   real(rtype) :: dz_zt(shcol,nlev)
@@ -409,6 +418,10 @@ subroutine shoc_main ( &
      qw,shoc_ql,u_wind,v_wind,&             ! Input
      se_b,ke_b,wv_b,wl_b)                   ! Input/Output
 
+  ! First substep uses the host-supplied thv unchanged (bit-for-bit with
+  ! the original behavior when nadv = 1); later substeps refresh it below.
+  shoc_thv(:,:) = thv(:,:)
+
   do t=1,nadv
 
     ! Check TKE to make sure values lie within acceptable
@@ -437,6 +450,18 @@ subroutine shoc_main ( &
        shcol,nlev,thetal,shoc_ql,inv_exner,& ! Input
        shoc_tabs)                            ! Output
 
+    ! Refresh the virtual potential temperature from the current substep
+    ! state so shoc_length does not see a stale thv when nadv > 1.  Built
+    ! from SHOC's own diagnosed temperature (shoc_tabs) and vapor (shoc_qv)
+    ! computed just above, mirroring the host-side formula (shoc_intr.F90):
+    !   thv = T * inv_exner * (1 + zvir*qv - ql),  with eps = zvir here.
+    ! The first substep keeps the host-supplied thv so that nadv = 1
+    ! configurations remain bit-for-bit.
+    if (t .gt. 1) then
+       shoc_thv(:,:) = shoc_tabs(:,:) * inv_exner(:,:) &
+                       * (1.0_rtype + eps * shoc_qv(:,:) - shoc_ql(:,:))
+    endif
+
     call shoc_diag_obklen(&
        shcol,uw_sfc,vw_sfc,&                          ! Input
        wthl_sfc,wqw_sfc,thetal(:shcol,nlev),&         ! Input
@@ -450,12 +475,14 @@ subroutine shoc_main ( &
        ustar,obklen,kbfs,shoc_cldfrac,&     ! Input
        pblh)                                ! Output
 
-    ! Update the turbulent length scale
+    ! Update the turbulent length scale.  Note: shoc_thv (refreshed each
+    ! substep above) is used instead of the intent(in) thv so that
+    ! compute_brunt_shoc_length sees the current substep state.
     call shoc_length(&
        shcol,nlev,nlevi,&                ! Input
        host_dx,host_dy,&                 ! Input
        zt_grid,zi_grid,dz_zt,&           ! Input
-       tke,thv,&                         ! Input
+       tke,shoc_thv,&                    ! Input
        brunt,shoc_mix)                   ! Output
 
     ! Advance the SGS TKE equation

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -169,7 +169,7 @@ size_t SHOCMacrophysics::requested_buffer_size_in_bytes() const
   const auto policy       = TPF::get_default_team_policy(m_num_cols, nlev_packs);
   const int n_wind_slots  = ekat::npack<Pack>(2)*Pack::n;
   const int n_trac_slots  = ekat::npack<Pack>(m_num_tracers+3)*Pack::n;
-  const size_t wsm_request= WSM::get_total_bytes_needed(nlevi_packs, 14+(2*n_wind_slots+n_trac_slots), policy);
+  const size_t wsm_request= WSM::get_total_bytes_needed(nlevi_packs, 15+(2*n_wind_slots+n_trac_slots), policy);
 
   return interface_request + wsm_request;
 }
@@ -216,7 +216,7 @@ void SHOCMacrophysics::init_buffers(const ATMBufferManager &buffer_manager)
     &m_buffer.shoc_ql2, &m_buffer.shoc_mix, &m_buffer.isotropy, &m_buffer.w_sec, &m_buffer.wqls_sec, &m_buffer.brunt,
     &m_buffer.um_pert, &m_buffer.vm_pert
 #ifdef SCREAM_SHOC_SMALL_KERNELS
-    , &m_buffer.rho_zt, &m_buffer.shoc_qv, &m_buffer.tabs, &m_buffer.dz_zt
+    , &m_buffer.rho_zt, &m_buffer.shoc_qv, &m_buffer.tabs, &m_buffer.shoc_thv, &m_buffer.dz_zt
 #endif
   };
 
@@ -249,7 +249,7 @@ void SHOCMacrophysics::init_buffers(const ATMBufferManager &buffer_manager)
   const auto policy      = TPF::get_default_team_policy(m_num_cols, nlev_packs);
   const int n_wind_slots = ekat::npack<Pack>(2)*Pack::n;
   const int n_trac_slots = ekat::npack<Pack>(m_num_tracers+3)*Pack::n;
-  const int wsm_size     = WSM::get_total_bytes_needed(nlevi_packs, 14+(2*n_wind_slots+n_trac_slots), policy)/sizeof(Pack);
+  const int wsm_size     = WSM::get_total_bytes_needed(nlevi_packs, 15+(2*n_wind_slots+n_trac_slots), policy)/sizeof(Pack);
   s_mem += wsm_size;
 
   size_t used_mem = (reinterpret_cast<Real*>(s_mem) - buffer_manager.get_memory())*sizeof(Real);
@@ -430,6 +430,7 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
   temporaries.rho_zt = m_buffer.rho_zt;
   temporaries.shoc_qv = m_buffer.shoc_qv;
   temporaries.tabs = m_buffer.tabs;
+  temporaries.shoc_thv = m_buffer.shoc_thv;
   temporaries.dz_zt = m_buffer.dz_zt;
   temporaries.dz_zi = m_buffer.dz_zi;
 #endif
@@ -471,7 +472,7 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
   const int n_wind_slots = ekat::npack<Pack>(2)*Pack::n;
   const int n_trac_slots = ekat::npack<Pack>(m_num_tracers+3)*Pack::n;
   const auto default_policy = TPF::get_default_team_policy(m_num_cols, nlev_packs);
-  workspace_mgr.setup(m_buffer.wsm_data, nlevi_packs, 14+(2*n_wind_slots+n_trac_slots), default_policy);
+  workspace_mgr.setup(m_buffer.wsm_data, nlevi_packs, 15+(2*n_wind_slots+n_trac_slots), default_policy);
 
   // Calculate pref_mid, and use that to calculate
   // maximum number of levels in pbl from surface

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.hpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.hpp
@@ -443,7 +443,7 @@ public:
     static constexpr int num_2d_vector_mid  = 21;
     static constexpr int num_2d_vector_int  = 12;
 #else
-    static constexpr int num_2d_vector_mid  = 25;
+    static constexpr int num_2d_vector_mid  = 26;
     static constexpr int num_2d_vector_int  = 13;
 #endif
     static constexpr int num_2d_vector_tr   = 1;
@@ -508,6 +508,7 @@ public:
     uview_2d<Pack> rho_zt;
     uview_2d<Pack> shoc_qv;
     uview_2d<Pack> tabs;
+    uview_2d<Pack> shoc_thv;
     uview_2d<Pack> dz_zt;
     uview_2d<Pack> dz_zi;
     uview_2d<Pack> tkh;

--- a/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
@@ -151,10 +151,10 @@ void Functions<S,D>::shoc_main_internal(
 {
 
   // Define temporary variables
-  uview_1d<Pack> rho_zt, shoc_qv, shoc_tabs, dz_zt, dz_zi;
-  workspace.template take_many_and_reset<5>(
-    {"rho_zt", "shoc_qv", "shoc_tabs", "dz_zt", "dz_zi"},
-    {&rho_zt, &shoc_qv, &shoc_tabs, &dz_zt, &dz_zi});
+  uview_1d<Pack> rho_zt, shoc_qv, shoc_tabs, shoc_thv, dz_zt, dz_zi;
+  workspace.template take_many_and_reset<6>(
+    {"rho_zt", "shoc_qv", "shoc_tabs", "shoc_thv", "dz_zt", "dz_zi"},
+    {&rho_zt, &shoc_qv, &shoc_tabs, &shoc_thv, &dz_zt, &dz_zi});
 
   // Local scalars
   Scalar se_b{0},   ke_b{0},   wv_b{0}, wl_b{0},
@@ -172,6 +172,19 @@ void Functions<S,D>::shoc_main_internal(
   // conserves) and static energy (which E3SM conserves) are not exactly equal.
   shoc_energy_integrals(team,nlev,host_dse,pdel,qw,shoc_ql,u_wind,v_wind, // Input
                         se_b,ke_b,wv_b,wl_b);                             // Output
+
+  // The host-supplied thv is computed once per shoc_main call and held
+  // constant, while thetal and qw evolve each substep
+  // (update_prognostics_implicit) and shoc_ql is re-diagnosed each substep
+  // (shoc_assumed_pdf).  When nadv > 1, substeps beyond the first would
+  // otherwise use a stale thv in shoc_length (-> compute_brunt_shoc_length).
+  // shoc_thv equals thv on the first substep (bit-for-bit with the original
+  // behavior when nadv = 1) and is refreshed from SHOC's own diagnosed state
+  // on later substeps.
+  const Int nlev_pack = ekat::npack<Pack>(nlev);
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_pack), [&] (const Int& k) {
+    shoc_thv(k) = thv(k);
+  });
 
   for (Int t=0; t<nadv; ++t) {
     // Check TKE to make sure values lie within acceptable
@@ -200,6 +213,23 @@ void Functions<S,D>::shoc_main_internal(
                              shoc_tabs);        // Output
 
     team.team_barrier();
+
+    // Refresh the virtual potential temperature from the current substep
+    // state so shoc_length does not see a stale thv when nadv > 1.  Built
+    // from SHOC's own diagnosed temperature (shoc_tabs) and vapor (shoc_qv)
+    // computed just above, mirroring the host-side formula:
+    //   thv = T * inv_exner * (1 + zvir*qv - ql).
+    // The first substep keeps the host-supplied thv so that nadv = 1
+    // configurations remain bit-for-bit.
+    if (t > 0) {
+      const auto zvir = C::ZVIR;
+      const auto one  = C::ONE;
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_pack), [&] (const Int& k) {
+        shoc_thv(k) = shoc_tabs(k)*inv_exner(k)*(one + zvir*shoc_qv(k) - shoc_ql(k));
+      });
+      team.team_barrier();
+    }
+
     shoc_diag_obklen(uw_sfc,vw_sfc,     // Input
                      wthl_sfc, wqw_sfc, // Input
                      s_thetal(nlev-1),  // Input
@@ -215,12 +245,14 @@ void Functions<S,D>::shoc_main_internal(
             workspace,                // Workspace
             pblh);                    // Output
 
-    // Update the turbulent length scale
+    // Update the turbulent length scale.  Note: shoc_thv (refreshed each
+    // substep above) is used instead of the input thv so that
+    // compute_brunt_shoc_length sees the current substep state.
     shoc_length(team,nlev,nlevi,       // Input
                 length_fac,            // Runtime Options
                 dx,dy,                 // Input
                 zt_grid,zi_grid,dz_zt, // Input
-                tke,thv,               // Input
+                tke,shoc_thv,          // Input
                 workspace,             // Workspace
                 brunt,shoc_mix);       // Output
 
@@ -329,8 +361,8 @@ void Functions<S,D>::shoc_main_internal(
           pblh);                          // Output
 
   // Release temporary variables from the workspace
-  workspace.template release_many_contiguous<5>(
-    {&rho_zt, &shoc_qv, &shoc_tabs, &dz_zt, &dz_zi});
+  workspace.template release_many_contiguous<6>(
+    {&rho_zt, &shoc_qv, &shoc_tabs, &shoc_thv, &dz_zt, &dz_zi});
 }
 #else
 template<typename S, typename D>
@@ -430,6 +462,7 @@ void Functions<S,D>::shoc_main_internal(
   const view_2d<Pack>& rho_zt,
   const view_2d<Pack>& shoc_qv,
   const view_2d<Pack>& shoc_tabs,
+  const view_2d<Pack>& shoc_thv,
   const view_2d<Pack>& dz_zt,
   const view_2d<Pack>& dz_zi)
 {
@@ -444,6 +477,16 @@ void Functions<S,D>::shoc_main_internal(
   // conserves) and static energy (which E3SM conserves) are not exactly equal.
   shoc_energy_integrals_disp(shcol,nlev,host_dse,pdel,qw,shoc_ql,u_wind,v_wind,
                              se_b, ke_b, wv_b, wl_b); // Input
+
+  // The host-supplied thv is computed once per shoc_main call and held
+  // constant, while thetal and qw evolve each substep
+  // (update_prognostics_implicit) and shoc_ql is re-diagnosed each substep
+  // (shoc_assumed_pdf).  When nadv > 1, substeps beyond the first would
+  // otherwise use a stale thv in shoc_length (-> compute_brunt_shoc_length).
+  // shoc_thv equals thv on the first substep (bit-for-bit with the original
+  // behavior when nadv = 1) and is refreshed from SHOC's own diagnosed state
+  // on later substeps.
+  Kokkos::deep_copy(shoc_thv, thv);
 
   for (Int t=0; t<nadv; ++t) {
     // Check TKE to make sure values lie within acceptable
@@ -471,6 +514,26 @@ void Functions<S,D>::shoc_main_internal(
                                   shoc_ql,inv_exner, // Input
                                   shoc_tabs);        // Output
 
+    // Refresh the virtual potential temperature from the current substep
+    // state so shoc_length does not see a stale thv when nadv > 1.  Built
+    // from SHOC's own diagnosed temperature (shoc_tabs) and vapor (shoc_qv)
+    // computed just above, mirroring the host-side formula:
+    //   thv = T * inv_exner * (1 + zvir*qv - ql).
+    // The first substep keeps the host-supplied thv so that nadv = 1
+    // configurations remain bit-for-bit.
+    if (t > 0) {
+      const auto zvir = C::ZVIR;
+      const auto one  = C::ONE;
+      const Int nlev_packs = ekat::npack<Pack>(nlev);
+      Kokkos::parallel_for("shoc_main_refresh_thv",
+                           Kokkos::RangePolicy<typename KT::ExeSpace>(0, shcol*nlev_packs),
+                           KOKKOS_LAMBDA (const Int& idx) {
+        const Int i = idx / nlev_packs;
+        const Int k = idx % nlev_packs;
+        shoc_thv(i,k) = shoc_tabs(i,k)*inv_exner(i,k)*(one + zvir*shoc_qv(i,k) - shoc_ql(i,k));
+      });
+    }
+
     shoc_diag_obklen_disp(shcol, nlev,
                           uw_sfc,vw_sfc,     // Input
                           wthl_sfc, wqw_sfc, // Input
@@ -487,12 +550,14 @@ void Functions<S,D>::shoc_main_internal(
                  workspace_mgr,            // Workspace mgr
                  pblh);                    // Output
 
-    // Update the turbulent length scale
+    // Update the turbulent length scale.  Note: shoc_thv (refreshed each
+    // substep above) is used instead of the input thv so that
+    // compute_brunt_shoc_length sees the current substep state.
     shoc_length_disp(shcol,nlev,nlevi,      // Input
                      length_fac,            // Runtime Options
                      dx,dy,                 // Input
                      zt_grid,zi_grid,dz_zt, // Input
-                     tke,thv,               // Input
+                     tke,shoc_thv,          // Input
                      workspace_mgr,         // Workspace mgr
                      brunt,shoc_mix);       // Output
 
@@ -755,7 +820,8 @@ Int Functions<S,D>::shoc_main(
     shoc_temporaries.se_a, shoc_temporaries.ke_a, shoc_temporaries.wv_a, shoc_temporaries.wl_a,
     shoc_temporaries.kbfs, shoc_temporaries.ustar2,
     shoc_temporaries.wstar, shoc_temporaries.rho_zt, shoc_temporaries.shoc_qv,
-    shoc_temporaries.tabs, shoc_temporaries.dz_zt, shoc_temporaries.dz_zi);
+    shoc_temporaries.tabs, shoc_temporaries.shoc_thv, shoc_temporaries.dz_zt,
+    shoc_temporaries.dz_zi);
 #endif
 
   auto finish = std::chrono::steady_clock::now();

--- a/components/eamxx/src/physics/shoc/shoc_functions.hpp
+++ b/components/eamxx/src/physics/shoc/shoc_functions.hpp
@@ -218,6 +218,7 @@ template <typename ScalarT, typename DeviceT> struct Functions {
     view_2d<Pack> rho_zt;
     view_2d<Pack> shoc_qv;
     view_2d<Pack> tabs;
+    view_2d<Pack> shoc_thv;
     view_2d<Pack> dz_zt;
     view_2d<Pack> dz_zi;
     view_2d<Pack> tkh;
@@ -771,8 +772,8 @@ template <typename ScalarT, typename DeviceT> struct Functions {
       const view_1d<Scalar> &wl_b, const view_1d<Scalar> &se_a, const view_1d<Scalar> &ke_a,
       const view_1d<Scalar> &wv_a, const view_1d<Scalar> &wl_a, const view_1d<Scalar> &kbfs,
       const view_1d<Scalar> &ustar2, const view_1d<Scalar> &wstar, const view_2d<Pack> &rho_zt,
-      const view_2d<Pack> &shoc_qv, const view_2d<Pack> &tabs, const view_2d<Pack> &dz_zt,
-      const view_2d<Pack> &dz_zi);
+      const view_2d<Pack> &shoc_qv, const view_2d<Pack> &tabs, const view_2d<Pack> &shoc_thv,
+      const view_2d<Pack> &dz_zt, const view_2d<Pack> &dz_zi);
 #endif
 
   // Return microseconds elapsed

--- a/components/eamxx/src/physics/shoc/tests/infra/shoc_test_data.cpp
+++ b/components/eamxx/src/physics/shoc/tests/infra/shoc_test_data.cpp
@@ -2432,21 +2432,22 @@ Int shoc_main_host(Int shcol, Int nlev, Int nlevi, Real dtime, Int nadv, Int npb
     wstar  ("wstar", shcol);
 
   view_2d
-    rho_zt  ("rho_zt",  shcol, nlevi_packs),
-    shoc_qv ("shoc_qv", shcol, nlevi_packs),
-    tabs    ("shoc_tabs", shcol, nlev_packs),
-    dz_zt   ("dz_zt",   shcol, nlevi_packs),
-    dz_zi   ("dz_zi",   shcol, nlevi_packs);
+    rho_zt   ("rho_zt",  shcol, nlevi_packs),
+    shoc_qv  ("shoc_qv", shcol, nlevi_packs),
+    tabs     ("shoc_tabs", shcol, nlev_packs),
+    shoc_thv ("shoc_thv", shcol, nlev_packs),
+    dz_zt    ("dz_zt",   shcol, nlevi_packs),
+    dz_zi    ("dz_zi",   shcol, nlevi_packs);
 
   SHF::SHOCTemporaries shoc_temporaries{
     se_b, ke_b, wv_b, wl_b, se_a, ke_a, wv_a, wl_a, kbfs, ustar2, wstar,
-    rho_zt, shoc_qv, tabs, dz_zt, dz_zi};
+    rho_zt, shoc_qv, tabs, shoc_thv, dz_zt, dz_zi};
 #endif
 
   // Create local workspace
   const int n_wind_slots = ekat::npack<Pack>(2)*Pack::n;
   const int n_trac_slots = ekat::npack<Pack>(num_qtracers+3)*Pack::n;
-  ekat::WorkspaceManager<Pack, SHF::KT::Device> workspace_mgr(nlevi_packs, 14+(2*n_wind_slots+n_trac_slots), policy);
+  ekat::WorkspaceManager<Pack, SHF::KT::Device> workspace_mgr(nlevi_packs, 15+(2*n_wind_slots+n_trac_slots), policy);
 
   const auto elapsed_microsec = SHF::shoc_main(shcol, nlev, nlevi, npbl, nadv, num_qtracers, dtime,
                                                workspace_mgr, shoc_runtime_options,


### PR DESCRIPTION
Fix stale virtual potential temperature (thv) in the shoc_main substep loop. The host-supplied thv is computed once per physics timestep, but inside SHOC's nadv substep loop thetal, qw, and shoc_ql all evolve, so substeps beyond the first used a stale thv in the Brunt-Vaisala frequency and hence the turbulent length scale. The fix refreshes thv each substep from SHOC's own diagnosed temperature and vapor, in both the EAM Fortran and EAMxx C++ implementations. Bit-for-bit for all nadv = 1 configurations (the default); answers change only when SHOC subcycles (shoc_timestep < host physics timestep).

---

## Summary

Fix a state-staleness bug in `shoc_main` (both the EAM Fortran and EAMxx C++ implementations).

The virtual potential temperature `thv` is computed by the host model once per physics timestep (`shoc_intr.F90` / `eamxx_shoc_process_interface.hpp`) and passed to `shoc_main` as a constant input. Inside the `nadv` substep loop, however:

- `thetal` and `qw` evolve each substep via `update_prognostics_implicit`,
- `shoc_ql` is re-diagnosed each substep by `shoc_assumed_pdf`,

while `thv` is never updated. Its only consumer inside the loop is `shoc_length` → `compute_brunt_shoc_length`, so when `nadv > 1` every substep after the first computes the Brunt–Väisälä frequency from a stale state, biasing `brunt`, the turbulent length scale (`shoc_mix`), and downstream TKE and higher moments. The rest of the closure sees the current substep state, making the length-scale calculation internally inconsistent with it.

## Fix

Introduce a local `shoc_thv` that:

1. equals the host-supplied `thv` on the first substep, and
2. is refreshed on later substeps from SHOC's own diagnosed temperature (`shoc_tabs`) and vapor (`shoc_qv`), computed immediately beforehand in the loop, mirroring the host-side formula:

```
thv = T * inv_exner * (1 + zvir*qv - ql)
```

`shoc_length` then receives `shoc_thv` instead of `thv`. At the refresh point `shoc_tabs = thetal/inv_exner + (Lv/cp)*shoc_ql` and `shoc_qv = qw - shoc_ql` are already the current-substep diagnostics, so the refreshed `shoc_thv` is exactly the thv the host would have computed from the evolved state.

Both implementations receive the same fix:

- **EAM Fortran**: `components/eam/src/physics/cam/shoc.F90` (local array + guarded refresh in the `nadv` loop).
- **EAMxx C++**: `shoc_main_impl.hpp`, default and `SCREAM_SHOC_SMALL_KERNELS` variants. `shoc_thv` is added to the SHOC workspace (slot count 14 → 15) and to `SHOCTemporaries` (with buffer and test-infrastructure wiring).

## Expected answer changes

- **BFB for all `nadv = 1` configurations** — the first substep uses the host-supplied `thv` unchanged. This covers default EAM (`shoc_timestep = -1`, i.e. no subcycling) and current EAMxx, which presently forces `nadv = 1`.
- **Non-BFB (intended bug fix) only where SHOC subcycles** (`shoc_timestep <` host physics timestep): e.g. SCREAM-LR use cases (`shoc_timestep = 150`), SCM/DP configurations with SHOC substepping. In these configurations the largest differences appear where cloud liquid is present near strong inversions (e.g. stratocumulus-topped boundary layers), since the stale `thv` error grows with the evolution of `thetal`/`qw`/`shoc_ql` across substeps.
- **Test-suite implication**: the EAMxx standalone shoc_main baseline-comparison tests also subcycle (nadv = 5–15), so they fall in the non-BFB category — their stored baselines will need regeneration on merge. The property/unit tests are unaffected (they check invariants, not stored values) and pass at nadv > 1.


